### PR TITLE
Changed Event Log type to say Toolkit_App_Startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -223,7 +223,7 @@ class LaunchApplication(tank.platform.Application):
         if ctx.task:
             meta["task"] = ctx.task["id"]
         desc =  "%s %s: %s" % (self.name, self.version, self.get_setting("menu_name"))
-        tank.util.create_event_log_entry(self.tank, ctx, "Tank_App_Startup", desc, meta)
+        tank.util.create_event_log_entry(self.tank, ctx, "Toolkit_App_Startup", desc, meta)
 
 
     def prepare_nuke_launch(self, file_to_open, app_args):


### PR DESCRIPTION
This changes the Event Type in the Event log records that are stored as applications are started up. These were previously kept as Tank_App_Startup but I wonder if now is a good time to change it over to Toolkit. 
