### PR TITLE
#27083 Adds setting which hides icons if application is not installed

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,8 +32,15 @@ class LaunchApplication(tank.platform.Application):
         # get the path setting for this platform:
         platform_name = {"linux2": "linux", "darwin": "mac", "win32": "windows"}[sys.platform]
         app_path = self.get_setting("%s_path" % platform_name, "")
+        perform_path_check = self.get_setting("%s_path_check" % platform_name, False)
+        
         if not app_path:
             # no application path defined for this os. So don't register a menu item!
+            return
+        
+        if perform_path_check and not os.path.exists(app_path):
+            # when perform_path_check is True, we check to determine the existence of
+            # the dcc launch command and if it cannot be found, no menu items are produced.
             return
 
         versions = self.get_setting("versions")

--- a/info.yml
+++ b/info.yml
@@ -29,7 +29,6 @@ configuration:
                    the correct operating system separator when used."
       default_value: "{target_engine}/icon_256.png"
 
-    # Path information for multiple platforms
     windows_path:
         type: str
         description: The path to the application executable on Windows.
@@ -38,6 +37,13 @@ configuration:
         type: str
         description: The arguments to be passed to application on Windows, as a string.
         default_value: ""
+
+    windows_path_check:
+        type: bool
+        description: "If this flag is set to true, the app will try to detect the path to
+                      the application on disk. If the application path is not found, no
+                      launch commands are registered." 
+        default_value: false
     
     linux_path:
         type: str
@@ -47,6 +53,13 @@ configuration:
         type: str
         description: The arguments to be passed to application on Linux, as a string.
         default_value: ""
+
+    linux_path_check:
+        type: bool
+        description: "If this flag is set to true, the app will try to detect the path to
+                      the application on disk. If the application path is not found, no
+                      launch commands are registered." 
+        default_value: false
     
     mac_path:
         type: str
@@ -56,6 +69,13 @@ configuration:
         type: str
         description: The arguments to be passed to application on Mac OS X, as a string.
         default_value: ""
+
+    mac_path_check:
+        type: bool
+        description: "If this flag is set to true, the app will try to detect the path to
+                      the application on disk. If the application path is not found, no
+                      launch commands are registered." 
+        default_value: false
     
     engine:
         type: str


### PR DESCRIPTION
Currently, there will be a "Launch Houdini" option in Shotgun and the shell (and a Houdini icon in the desktop) even if you haven't got Houdini installed.
This seems counter intuitive and this simple addition is trying to address that. It adds a small check to see if the DCC that is about to be launched actually exists. If not, the launch command (icon) is never registered with the engine, and will therefore not be visible to the user.

The behaviour is controlled by a preference, which defaults to the current behaviour, meaning that the upgrade is backwards compatible.
Turning off this logic is necessary in cases where you don't have an absolute path to the DCC and therefore cannot check it.
