### PR TITLE
For #26727, Update multi-launchapp to push/pop environment changes.

### DIFF
--- a/app.py
+++ b/app.py
@@ -209,13 +209,17 @@ class LaunchApplication(tank.platform.Application):
 
     def _launch_app(self, context, file_to_open=None, version=None):
         """
-        Launches an app
+        Launches an application. No environment variable change is leaked to the outside world.
+        :param context: Tank context we will opening the app in.
+        :param file_to_open: Optional file to open when the app launches. Can be None.
+        :param version: Version of the app to launch. Specifying None means the default version will
+                        be picked.
         """
         try:
             # Clone the environment variables
             environ_clone = os.environ.copy()
             sys_path_clone = sys.path[:]
-            self._launch_app_internal(context, file_to_open, version)
+            self.__launch_app_internal(context, file_to_open, version)
         finally:
             # Clear the original structures and add into them so that users who did
             # from os import environ and from sys import path get the restored values.
@@ -225,9 +229,14 @@ class LaunchApplication(tank.platform.Application):
             del sys.path[:]
             sys.path.extend(sys_path_clone)
 
-    def _launch_app_internal(self, context, file_to_open=None, version=None):
+    def __launch_app_internal(self, context, file_to_open=None, version=None):
         """
-        Launches an app
+        Launches an application. This method may have side-effects in the environment variables table.
+        Call the _launch_app method instead.
+        :param context: Tank context we will opening the app in.
+        :param file_to_open: Optional file to open when the app launches. Can be None.
+        :param version: Version of the app to launch. Specifying None means the default version will
+                        be picked.
         """
         # get the executable path
         app_path = self._get_app_path(version)

--- a/app.py
+++ b/app.py
@@ -210,7 +210,7 @@ class LaunchApplication(tank.platform.Application):
     def _launch_app(self, context, file_to_open=None, version=None):
         """
         Launches an application. No environment variable change is leaked to the outside world.
-        :param context: Tank context we will opening the app in.
+        :param context: Toolkit context we will opening the app in.
         :param file_to_open: Optional file to open when the app launches. Can be None.
         :param version: Version of the app to launch. Specifying None means the default version will
                         be picked.
@@ -218,22 +218,21 @@ class LaunchApplication(tank.platform.Application):
         try:
             # Clone the environment variables
             environ_clone = os.environ.copy()
-            sys_path_clone = sys.path[:]
-            self.__launch_app_internal(context, file_to_open, version)
+            sys_path_clone = list(sys.path)
+            self._launch_app_internal(context, file_to_open, version)
         finally:
             # Clear the original structures and add into them so that users who did
             # from os import environ and from sys import path get the restored values.
             os.environ.clear()
-            for k, v in environ_clone.items():
-                os.environ[k] = v
+            os.environ.update(environ_clone)
             del sys.path[:]
             sys.path.extend(sys_path_clone)
 
-    def __launch_app_internal(self, context, file_to_open=None, version=None):
+    def _launch_app_internal(self, context, file_to_open=None, version=None):
         """
         Launches an application. This method may have side-effects in the environment variables table.
         Call the _launch_app method instead.
-        :param context: Tank context we will opening the app in.
+        :param context: Toolkit context we will opening the app in.
         :param file_to_open: Optional file to open when the app launches. Can be None.
         :param version: Version of the app to launch. Specifying None means the default version will
                         be picked.

--- a/app.py
+++ b/app.py
@@ -211,6 +211,24 @@ class LaunchApplication(tank.platform.Application):
         """
         Launches an app
         """
+        try:
+            # Clone the environment variables
+            environ_clone = os.environ.copy()
+            sys_path_clone = sys.path[:]
+            self._launch_app_internal(context, file_to_open, version)
+        finally:
+            # Clear the original structures and add into them so that users who did
+            # from os import environ and from sys import path get the restored values.
+            os.environ.clear()
+            for k, v in environ_clone.items():
+                os.environ[k] = v
+            del sys.path[:]
+            sys.path.extend(sys_path_clone)
+
+    def _launch_app_internal(self, context, file_to_open=None, version=None):
+        """
+        Launches an app
+        """
         # get the executable path
         app_path = self._get_app_path(version)
 
@@ -413,9 +431,6 @@ class LaunchApplication(tank.platform.Application):
         except Exception:
             self.log_exception("Error executing engine bootstrap script.")
             raise TankError("Error executing bootstrap script. Please see log for details.")
-        finally:
-            # remove bootstrap from sys.path
-            sys.path.pop(0)
 
         return (app_path, new_args)
 
@@ -609,9 +624,6 @@ class LaunchApplication(tank.platform.Application):
         except:
             self.log_exception("Error executing engine bootstrap script.")
             raise TankError("Error executing bootstrap script. Please see log for details.")
-        finally:
-            # remove bootstrap from sys.path
-            sys.path.pop(0)
         
         return (app_path, new_args)
 


### PR DESCRIPTION
- Before doing any bootstrapping of an engine, we backup os.environ and os.path so that bootstrapping code can be careless with updating and restoring these two variables.
- Removed code that tried to keep the environment clean.