### PR TITLE
#28374 improved error when trying to run 3dsmax 2015 with the old engine

### DIFF
--- a/app_specific/3dsmax/startup/init_tank.ms
+++ b/app_specific/3dsmax/startup/init_tank.ms
@@ -1,3 +1,6 @@
+-- This is a wrapper around the Toolkit bootstrap python script for the tk-3dsmax
+-- engine. It requires the Blur Python extensions and will raise an error if they 
+-- are not found.
 if ( python != undefined ) then 
 (
     if ( _blurLibrary != undefined ) then
@@ -9,6 +12,9 @@ if ( python != undefined ) then
 
     if ( bootstrap_script != undefined ) then 
     (
+        -- Since 2015+ uses the native built-in Python, this Blur-specific function
+        -- won't exist. This catches a common use-case where users upgrade to 2015+
+        -- but don't update their Launcher to use the new tk-3dsmaxplus engine. 
         try
         (
             python.run( bootstrap_script )

--- a/app_specific/3dsmax/startup/init_tank.ms
+++ b/app_specific/3dsmax/startup/init_tank.ms
@@ -9,13 +9,18 @@ if ( python != undefined ) then
 
     if ( bootstrap_script != undefined ) then 
     (
-        try 
+        try
         (
             python.run( bootstrap_script )
         )
         catch
         (
-            messageBox "Shotgun Pipeline Toolkit:\n\nYou are running a version of 3dsMax that is not supported by the tk-3dsmax engine.  If you intend to use 3dsMax's built-in Python support, please update your launcher settings to use the tk-3dsmaxplus engine."
+            error = getCurrentException()
+            is_wrong_engine = (findString error "Unknown property: \"run\" in <Interface:python>") 
+            if ( is_wrong_engine != undefined ) then
+                messageBox "Shotgun Pipeline Toolkit:\n\nYou are running a version of 3dsMax that is not supported by the tk-3dsmax engine.  If you intend to use 3dsMax's built-in Python support, please update your Launcher settings to use the tk-3dsmaxplus engine.\n\nIf you don't know how to update those settings, please email toolkitsupport@shotgunsoftware.com"
+            else
+                throw
         )
     )
     else

--- a/app_specific/3dsmax/startup/init_tank.ms
+++ b/app_specific/3dsmax/startup/init_tank.ms
@@ -9,7 +9,14 @@ if ( python != undefined ) then
 
     if ( bootstrap_script != undefined ) then 
     (
-        python.run( bootstrap_script )
+        try 
+        (
+            python.run( bootstrap_script )
+        )
+        catch
+        (
+            messageBox "Shotgun Pipeline Toolkit:\n\nYou are running a version of 3dsMax that is not supported by the tk-3dsmax engine.  If you intend to use 3dsMax's built-in Python support, please update your launcher settings to use the tk-3dsmaxplus engine."
+        )
     )
     else
     ( 


### PR DESCRIPTION
3dsmax 2015 requires the newer `tk-3dsmaxplus` engine to run. However, users may upgrade from older versions of 3dsmax and not realize this. Previously when doing so, they would get an unhelpful error message when the bootstrap script attempted to run on startup. This change catches the error at that point and displays a dialog explaining the need to use the newer `tk-3dsmaxplus` engine instead.