### PR TITLE
#33143 Better error message when flame is not found

### DIFF
--- a/app.py
+++ b/app.py
@@ -363,7 +363,7 @@ class LaunchApplication(tank.platform.Application):
             elif self.engine.has_ui:
                 # got UI support. Launch dialog with nice message
                 not_found_dialog = self.import_module("not_found_dialog")                
-                not_found_dialog.show_dialog(self, cmd)                
+                not_found_dialog.show_path_error_dialog(self, cmd)                
             
             else:
                 # traditional non-ui environment without any html support.
@@ -683,8 +683,14 @@ class LaunchApplication(tank.platform.Application):
             import bootstrap
             (app_path, new_args) = bootstrap.bootstrap(engine_name, context, app_path, app_args)            
             
-        except:
+        except Exception, e:
             self.log_exception("Error executing engine bootstrap script.")
+            
+            if self.engine.has_ui:
+                # got UI support. Launch dialog with nice message
+                not_found_dialog = self.import_module("not_found_dialog")                
+                not_found_dialog.show_generic_error_dialog(self, str(e))
+            
             raise TankError("Error executing bootstrap script. Please see log for details.")
         finally:
             # remove bootstrap from sys.path

--- a/python/not_found_dialog/__init__.py
+++ b/python/not_found_dialog/__init__.py
@@ -8,4 +8,4 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from .dialog import show_dialog
+from .dialog import show_path_error_dialog, show_generic_error_dialog

--- a/python/not_found_dialog/dialog.py
+++ b/python/not_found_dialog/dialog.py
@@ -14,18 +14,26 @@ from .ui.dialog import Ui_Dialog
 
 def show_path_error_dialog(app_instance, cmd_line):
     """
-    Shows the dialog.
+    Shows a modal dialog with information about an invalid path
+    
+    :param app_instance: App instance to associate dialog with 
+    :param cmd_line: Launch command line that should be displayed to the 
+                     user as part of the message
     """
     widget = app_instance.engine.show_dialog("Error launching Application", app_instance, AppDialog)
     widget.show_path_error_message(cmd_line)
     
 
-def show_generic_error_dialog(app_instance, cmd_line):
+def show_generic_error_dialog(app_instance, error_message):
     """
-    Shows the dialog.
+    Shows a modal dialog with information about a generic 
+    launch error.
+    
+    :param app_instance: App instance to associate dialog with 
+    :param cmd_line: Error message to present to the user 
     """
     widget = app_instance.engine.show_dialog("Error launching Application", app_instance, AppDialog)
-    widget.show_generic_error_message(cmd_line)
+    widget.show_generic_error_message(error_message)
 
 
 class AppDialog(QtGui.QWidget):
@@ -41,33 +49,38 @@ class AppDialog(QtGui.QWidget):
         QtGui.QWidget.__init__(self)
         
         # now load in the UI that was created in the UI designer
-        self.ui = Ui_Dialog() 
+        self.ui = Ui_Dialog()
         self.ui.setupUi(self)
         
         self.ui.learn_more.clicked.connect(self._launch_docs)
         
     def show_path_error_message(self, cmd_line):
         """
+        Display an error message that explains to the user that the app launch
+        path is incorrect.
         
+        :param cmd_line: Launch command line that should be displayed to the 
+                         user as part of the message
         """
         msg = ("<b style='color: rgb(252, 98, 70)'>Failed to launch application!</b> This is most likely because the path "
                "is not set correctly. The command that was used to attempt to launch is '%s'. "
                "<br><br>Click the button below to learn more about how to configure Toolkit to launch "
                "applications." %  cmd_line)
         
-        self.ui.message.setText(msg)        
+        self.ui.message.setText(msg)
 
-    def show_generic_error_message(self, error_msg):
+    def show_generic_error_message(self, error_message):
         """
+        Display a generic launch error message to the user.
         
+        :param error_message: Error message to present to the user.
         """
         msg = ("<b style='color: rgb(252, 98, 70)'>Failed to launch application!</b> "
                "<br><br>The following error was reported: <b>%s</b>"
                "<br><br>Click the button below to learn more about how to configure Toolkit to launch "
-               "applications." %  error_msg)
+               "applications." %  error_message)
         
-        self.ui.message.setText(msg)        
-        
+        self.ui.message.setText(msg)
         
     def _launch_docs(self):
         """

--- a/python/not_found_dialog/dialog.py
+++ b/python/not_found_dialog/dialog.py
@@ -12,11 +12,20 @@ import sgtk
 from sgtk.platform.qt import QtCore, QtGui
 from .ui.dialog import Ui_Dialog
 
-def show_dialog(app_instance, cmd_line):
+def show_path_error_dialog(app_instance, cmd_line):
     """
     Shows the dialog.
     """
-    app_instance.engine.show_dialog("Error launching Application", app_instance, AppDialog, cmd_line)
+    widget = app_instance.engine.show_dialog("Error launching Application", app_instance, AppDialog)
+    widget.show_path_error_message(cmd_line)
+    
+
+def show_generic_error_dialog(app_instance, cmd_line):
+    """
+    Shows the dialog.
+    """
+    widget = app_instance.engine.show_dialog("Error launching Application", app_instance, AppDialog)
+    widget.show_generic_error_message(cmd_line)
 
 
 class AppDialog(QtGui.QWidget):
@@ -24,7 +33,7 @@ class AppDialog(QtGui.QWidget):
     Not found UI dialog.
     """
     
-    def __init__(self, cmd_line):
+    def __init__(self):
         """
         Constructor
         """
@@ -35,13 +44,30 @@ class AppDialog(QtGui.QWidget):
         self.ui = Ui_Dialog() 
         self.ui.setupUi(self)
         
+        self.ui.learn_more.clicked.connect(self._launch_docs)
+        
+    def show_path_error_message(self, cmd_line):
+        """
+        
+        """
         msg = ("<b style='color: rgb(252, 98, 70)'>Failed to launch application!</b> This is most likely because the path "
                "is not set correctly. The command that was used to attempt to launch is '%s'. "
                "<br><br>Click the button below to learn more about how to configure Toolkit to launch "
                "applications." %  cmd_line)
         
         self.ui.message.setText(msg)        
-        self.ui.learn_more.clicked.connect(self._launch_docs)
+
+    def show_generic_error_message(self, error_msg):
+        """
+        
+        """
+        msg = ("<b style='color: rgb(252, 98, 70)'>Failed to launch application!</b> "
+               "<br><br>The following error was reported: <b>%s</b>"
+               "<br><br>Click the button below to learn more about how to configure Toolkit to launch "
+               "applications." %  error_msg)
+        
+        self.ui.message.setText(msg)        
+        
         
     def _launch_docs(self):
         """


### PR DESCRIPTION
Previously, if the path to flame wasn't found, an error message was written to the desktop logs which was highly confusing and hard to find. With this change, a message box pops up similar to the one being shown for other apps. The reason things are different for Flame is because the launch sequence is far more complex.

For other apps, the message displayed will look something like this:

![image](https://cloud.githubusercontent.com/assets/337710/10935619/24e4059e-82df-11e5-8232-6a4aecc38d0f.png)

For Flame, the message box displayed will look like this:

![image](https://cloud.githubusercontent.com/assets/337710/10935765/34aafdba-82e0-11e5-8422-cda58fc41932.png)
