### PR TITLE
#35247 remove version warning

### DIFF
--- a/app.py
+++ b/app.py
@@ -84,9 +84,6 @@ class LaunchApplication(tank.platform.Application):
         else:
             icon = self._translate_version_tokens(raw_icon, version)
             menu_name = self._translate_version_tokens(raw_menu_name, version)
-            if menu_name == raw_menu_name:
-                # No replacement happened with multiple versions, warn
-                self.log_warning("versions defined, but no $version token found in menu_name.")
 
         # the command name mustn't contain spaces and funny chars, so sanitize it.
         # Also, should be nice for the shell engine.

--- a/info.yml
+++ b/info.yml
@@ -81,7 +81,11 @@ configuration:
                       conjunction with launching of apps which do not have a toolkit engine defined - for these 
                       app launch instances, the engine setting is left blank, and therefore no engine name is passed
                       into the deferred folder creation. In such cases you can utilize this parameter to control
-                      the deferred folder creation."
+                      the deferred folder creation. 
+
+                      You can specify multiple keywords using a comma as a delimiter (eg. 'nuke, nuke_x').
+                      This will trigger folder creation for folders in your schema that have any
+                      of these values in their deferred folder creation setting."
 
     versions:
         type: list


### PR DESCRIPTION
Previously when you specified versions in your launcher instance settings, but didn't use any version tokens in the instance menu name, a warning would be emitted: 

```
versions defined, but no $version token found in menu_name
```

This warning was misleading and unnecessary. So we've now removed it altogether. 

Also added some documentation for a related change in shotgunsoftware/tk-core@84fa565173c1905a2a906522b7642250e9f33adb
