### PR TITLE
[minor] Set software entity args default value to "", not None

### DIFF
--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -126,7 +126,7 @@ class SoftwareEntityLauncher(BaseLauncher):
             app_icon = sw_entity["image"]
             app_engine = sw_entity["sg_engine"]
             app_path = sw_entity[app_path_field]
-            app_args = sw_entity[app_args_field]
+            app_args = sw_entity[app_args_field] or ""
 
             if not app_path:
                 # If no path has been set for the app, we will eventually go look for one,


### PR DESCRIPTION
For #38944, Addresses QA fix for error dialog when launching Nuke on Windows.  The None value returned from Shotgun when the Sofware entity args field is not set was being converted to a string "None" and passed on the command line to Nuke, which attempted to open it as a file.