### PR TITLE
38957 auto detect paths

### DIFF
--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -255,7 +255,6 @@ class BaseLauncher(object):
             environ_clone = os.environ.copy()
             sys_path_clone = list(sys.path)
 
-            launch_info = None
             engine_launcher = self._engine_launcher(app_engine)
             if sw_version and engine_launcher:
                 launch_args = apply_version_to_setting(app_args, sw_version.version)

--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -102,13 +102,17 @@ class BaseLauncher(object):
             }
 
             def launch_version():
-                self._launch_callback(menu_name, app_engine, app_path, app_args, version)
+                self._launch_callback(
+                    menu_name, app_engine, app_path, app_args, version
+                )
 
             self._tk_app.log_debug(
                 "Registering command %s to launch %s with args %s for engine %s" %
                 (command_name, app_path, app_args, app_engine)
             )
-            self._tk_app.engine.register_command(command_name, launch_version, properties)
+            self._tk_app.engine.register_command(
+                command_name, launch_version, properties
+            )
 
     def _launch_app(
             self, menu_name, app_engine, app_path, app_args, context,
@@ -167,7 +171,8 @@ class BaseLauncher(object):
             dll_directory_cache = clear_dll_directory()
             try:
                 # Launch the application
-                self._tk_app.log_debug("Launching executable '%s' with args '%s'" %
+                self._tk_app.log_debug(
+                    "Launching executable '%s' with args '%s'" %
                     (app_path, app_args)
                 )
                 result = self._tk_app.execute_hook(
@@ -183,14 +188,14 @@ class BaseLauncher(object):
             if return_code != 0:
                 # some special logic here to decide how to display failure feedback
                 if app_engine == "tk-shotgun":
-                    # for the shotgun engine, use the log info in order to get the proper
-                    # html formatting
+                    # for the shotgun engine, use the log info in order to
+                    # get the proper html formatting
                     self._tk_app.log_info(
                         "<b>Failed to launch application!</b> "
                         "This is most likely because the path is not set correctly."
                         "The command that was used to attempt to launch is '%s'. "
-                        "<br><br><a href='%s' target=_new>Click here</a> to learn more about "
-                        "how to setup your app launch configuration." %
+                        "<br><br><a href='%s' target=_new>Click here</a> to learn "
+                        "more about how to setup your app launch configuration." %
                         (launch_cmd, self._tk_app.HELP_DOC_URL)
                     )
 
@@ -202,11 +207,11 @@ class BaseLauncher(object):
                 else:
                     # traditional non-ui environment without any html support.
                     self._tk_app.log_error(
-                        "Failed to launch application! This is most likely because the path "
-                        "is not set correctly. The command that was used to attempt to launch "
-                        "is '%s'. To learn more about how to set up your app launch "
-                        "configuration, see the following documentation: %s" %
-                        (launch_cmd, self._tk_app.HELP_DOC_URL)
+                        "Failed to launch application! This is most likely because "
+                        "the path is not set correctly. The command that was used "
+                        "to attempt to launch is '%s'. To learn more about how to "
+                        "set up your app launch configuration, see the following "
+                        "documentation: %s" % (launch_cmd, self._tk_app.HELP_DOC_URL)
                     )
 
             else:
@@ -262,7 +267,9 @@ class BaseLauncher(object):
         """
         # Verify a Project is defined in the context.
         if self._tk_app.context.project is None:
-            raise TankError("Your context does not have a project defined. Cannot continue.")
+            raise TankError(
+                "Your context does not have a project defined. Cannot continue."
+            )
 
         # Extract an entity type and id from the context.
         entity_type = self._tk_app.context.project["type"]
@@ -284,18 +291,22 @@ class BaseLauncher(object):
             )
 
         else:
-            # Do the folder creation. If there is a specific defer keyword, this takes
-            # precedence. Otherwise, use the engine name for the DCC application by default.
+            # Do the folder creation. If there is a specific defer keyword,
+            # this takes precedence. Otherwise, use the engine name for the
+            # DCC application by default.
             defer_keyword = self._tk_app.get_setting("defer_keyword") or app_engine
             try:
-                self._tk_app.log_info("Creating folders for %s %s. Defer keyword: '%s'" %
+                self._tk_app.log_info(
+                    "Creating folders for %s %s. Defer keyword: '%s'" %
                     (entity_type, entity_id, defer_keyword)
                 )
                 self._tk_app.sgtk.create_filesystem_structure(
                     entity_type, entity_id, engine=defer_keyword
                 )
             except sgtk.TankError, err:
-                raise TankError("Could not create folders on disk. Error reported: %s" % err)
+                raise TankError(
+                    "Could not create folders on disk. Error reported: %s" % err
+                )
 
         # Launch the DCC
         self._launch_app(
@@ -304,16 +315,19 @@ class BaseLauncher(object):
 
     def register_launch_commands(self):
         """
-        Abstract method implemented by derived classes to envoke _register_launch_command()
+        Abstract method implemented by derived classes to
+        envoke _register_launch_command()
         """
         raise NotImplementedError
 
     def launch_from_path(self, path, version=None):
         """
-        Abstract method that can optionally be implemented by derived classes
+        Abstract method that can optionally be implemented by
+        derived classes
 
         :param path: File path DCC should open after launch.
-        :param version: (Optional) Specific version of DCC to launch.
+        :param version: (optional) Specific version of DCC
+                        to launch.
         """
         raise NotImplementedError
 

--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -232,7 +232,7 @@ class BaseLauncher(object):
 
     def _launch_app(
             self, menu_name, app_engine, app_path, app_args, context,
-            version=None, sw_version=None, file_to_open=None
+            version=None, file_to_open=None, sw_version=None,
         ):
         """
         Launches an application. No environment variable change is
@@ -381,7 +381,7 @@ class BaseLauncher(object):
         )
 
     def _launch_callback(
-            self, menu_name, app_engine, app_path, app_args, version, sw_version=None
+            self, menu_name, app_engine, app_path, app_args, version=None, sw_version=None
         ):
         """
         Default method to launch DCC application command based on the current context.
@@ -434,7 +434,8 @@ class BaseLauncher(object):
 
         # Launch the DCC
         self._launch_app(
-            menu_name, app_engine, app_path, app_args, self._tk_app.context, version, sw_version
+            menu_name, app_engine, app_path, app_args,
+            self._tk_app.context, version, None, sw_version
         )
 
     def _engine_launcher(self, engine_name):

--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -32,11 +32,131 @@ class BaseLauncher(object):
         """
         # Retrieve the TK Application from the current bundle
         self._tk_app = sgtk.platform.current_bundle()
+        self.__engine_launchers = {}
 
         # Store the current platform value
         self._platform_name = {
             "linux2": "linux", "darwin": "mac", "win32": "windows"
         }[sys.platform]
+
+    def _register_software_version_command(self, sw_version, app_args, app_engine):
+        """
+        Register a launch command with the current engine deriving the
+        required information from a SoftwareVersion instance.
+
+        :param sw_version: SoftwareVersion instance to retrieve launch information from.
+        :param app_args: Args string to pass to the DCC at launch time
+        :param app_engine: The TK engine associated with the DCC to be launched
+        """
+        # First determine a command name from the SoftwareVersion display name.
+        command_name = sw_version.display_name.lower().replace(" ", "_")
+        if command_name.endswith("..."):
+            command_name = command_name[:-3]
+
+        # Populate the properties dictionary to pass to the launch command.
+        properties = {
+            "title": sw_version.display_name,
+            "short_name": command_name,
+            "description": "Launches and initializes an application environment",
+            "icon": sw_version.icon,
+        }
+
+        # Define the callback method for the command
+        def launch_software_version():
+            self._launch_callback(None, app_engine, None, app_args, None, sw_version)
+
+        # Register the command with the current engine.
+        self._tk_app.log_debug(
+            "Registering command %s to use the %s SoftwareLauncher" %
+            (command_name, app_engine)
+        )
+        self._tk_app.engine.register_command(
+            command_name, launch_software_version, properties
+        )
+
+    def _register_software_version_commands(
+            self, app_menu_name, app_icon, app_engine, app_path, app_args, app_versions
+        ):
+        """
+        Create SoftwareVersion instances using a TK engine launcher constructed for the
+        input app_engine. Actual commands for these SoftwareVersions will be registered
+        with the engine via the _register_software_version_command() method.
+
+        :param app_menu_name: Menu name to display to launch this DCC. This is
+                              also used to construct the associated command name.
+        :param app_icon: Icon to display for this DCC
+        :param app_engine: The TK engine associated with the DCC to be launched
+        :param app_path: Full path name to the DCC. This may contain environment
+                         variables and/or the locally supported {version}, {v0},
+                         {v1}, ... variables
+        :param app_args: Args string to pass to the DCC at launch time
+        :param app_versions: Specifc list of DCC versions to create commands for.
+        """
+        # special case! @todo: fix this.
+        # this is to allow this app to be loaded for sg entities of
+        # type publish but not show up on the Shotgun menu. The
+        # launch_from_path() and launch_from_path_and_context()
+        # methods for this app should be used for these environments
+        # instead. These methods are normally accessed via a hook.
+        skip_environments = [
+            "shotgun_tankpublishedfile",
+            "shotgun_publishedfile",
+            "shotgun_version",
+        ]
+        if self._tk_app.engine.environment.get("name") in skip_environments:
+            self._tk_app.log_debug(
+                "Engine Launcher commands not supported in environment %s" %
+                self._tk_app.engine.environment["name"]
+            )
+            return
+
+        # Attempt to initialize a TK engine SoftwareLauncher for the specified
+        # engine name.
+        engine_launcher = self._engine_launcher(app_engine)
+        if not engine_launcher:
+            self._tk_app.log_debug(
+                "Could not initialize SoftwareLauncher for TK engine %s." %
+                app_engine
+            )
+            return
+
+        sw_versions = []
+        if app_path:
+            # If a path to the DCC has been specified, use the SoftwareLauncher
+            # to resolve the relevant SoftwareVersion(s). Multiple SoftwareVersions
+            # will be returned only if multiple app versions have been specified
+            # and exist.
+            if isinstance(app_versions, list):
+                for version in app_versions:
+                    sw_path = os.path.expandvars(
+                        apply_version_to_setting(app_path, version)
+                    )
+                    sw_version = engine_launcher.resolve_software(sw_path)
+                    if sw_version:
+                        sw_versions.append(sw_version)
+            else:
+                # No versions specfied, simply resolve the input path.
+                sw_path = os.path.expandvars(app_path)
+                sw_version = engine_launcher.resolve_software(sw_path)
+                if sw_version:
+                    sw_versions.append(sw_version)
+        else:
+            # If no path has been specified, have the SoftwareLauncher scan
+            # the system for valid SoftwareVersions. Limit to any versions
+            # specifically requested.
+            sw_versions = engine_launcher.scan_software(app_versions)
+
+        for sw_version in sw_versions:
+            if app_menu_name:
+                # Override the default menu name if one was specified.
+                use_menu_name = apply_version_to_setting(app_menu_name, sw_version.version)
+                sw_version.display_name = use_menu_name
+            if app_icon:
+                # Override the default icon if one was specified.
+                sw_version.icon = app_icon
+
+            # Register a command with the current engine to launch this SoftwareVersion
+            self._register_software_version_command(sw_version, app_args, app_engine)
 
     def _register_launch_command(
             self,
@@ -110,7 +230,10 @@ class BaseLauncher(object):
             )
             self._tk_app.engine.register_command(command_name, launch_version, properties)
 
-    def _launch_app(self, menu_name, app_engine, app_path, app_args, context, version=None, file_to_open=None):
+    def _launch_app(
+            self, menu_name, app_engine, app_path, app_args, context,
+            version=None, sw_version=None, file_to_open=None
+        ):
         """
         Launches an application. No environment variable change is
         leaked to the outside world.
@@ -132,22 +255,36 @@ class BaseLauncher(object):
             environ_clone = os.environ.copy()
             sys_path_clone = list(sys.path)
 
-            # Get the executable path path and args. Adjust according to
-            # the relevant engine.
-            app_path = apply_version_to_setting(app_path, version)
-            app_args = apply_version_to_setting(app_args, version)
-            if app_engine:
-                (prepped_path, prepped_args) = prepare_launch_for_engine(
-                    app_engine, app_path, app_args, context, file_to_open
+            launch_info = None
+            engine_launcher = self._engine_launcher(app_engine)
+            if sw_version and engine_launcher:
+                launch_args = apply_version_to_setting(app_args, sw_version.version)
+                launch_info = engine_launcher.prepare_launch(
+                    sw_version, launch_args, None, file_to_open
                 )
-                # QUESTION: Since *some* of the "prep" methods may modify
-                # the app_path and app_args values (e.g. _prepare_flame_flare_launch),
-                # should they be reset here like this?
-                # (This is not what it does currently)
-                app_path = prepped_path or app_path
-                app_args = prepped_args or app_args
+                app_path = launch_info.path
+                app_args = launch_info.args
+                os.environ.clear()
+                os.environ.update(launch_info.environment)
+                version_string = sw_version.version
 
-            version_string = get_clean_version_string(version)
+            else:
+                # Get the executable path path and args. Adjust according to
+                # the relevant engine.
+                app_path = apply_version_to_setting(app_path, version)
+                app_args = apply_version_to_setting(app_args, version)
+                if app_engine:
+                    (prepped_path, prepped_args) = prepare_launch_for_engine(
+                        app_engine, app_path, app_args, context, file_to_open
+                    )
+                    # QUESTION: Since *some* of the "prep" methods may modify
+                    # the app_path and app_args values (e.g. _prepare_flame_flare_launch),
+                    # should they be reset here like this?
+                    # (This is not what it does currently)
+                    app_path = prepped_path or app_path
+                    app_args = prepped_args or app_args
+
+                version_string = get_clean_version_string(version)
 
             # run before launch hook
             self._tk_app.log_debug("Running before app launch hook...")
@@ -244,7 +381,9 @@ class BaseLauncher(object):
             self._tk_app.sgtk, ctx, "Toolkit_App_Startup", desc, meta
         )
 
-    def _launch_callback(self, menu_name, app_engine, app_path, app_args, version=None):
+    def _launch_callback(
+            self, menu_name, app_engine, app_path, app_args, version, sw_version=None
+        ):
         """
         Default method to launch DCC application command based on the current context.
 
@@ -295,7 +434,27 @@ class BaseLauncher(object):
                 raise TankError("Could not create folders on disk. Error reported: %s" % err)
 
         # Launch the DCC
-        self._launch_app(menu_name, app_engine, app_path, app_args, self._tk_app.context, version)
+        self._launch_app(
+            menu_name, app_engine, app_path, app_args, self._tk_app.context, version, sw_version
+        )
+
+    def _engine_launcher(self, engine_name):
+        """
+        Attempt to create a SoftwareLauncher for the specified engine name.
+        Keep track of which SoftwareLaunchers have been created for optimization.
+
+        :param engine_name: Name of the Toolkit engine to create a SoftwareLauncher
+                            instance for.
+        :returns: Instance of SoftwareLauncher associated with the engine_name or None.
+        """
+        # Make sure the create method is available from tk-core.
+        if "create_engine_launcher" in dir(sgtk.platform):
+            if engine_name not in self.__engine_launchers:
+                self.__engine_launchers[engine_name] = sgtk.platform.create_engine_launcher(
+                    self._tk_app.sgtk, self._tk_app.context, engine_name
+                )
+            return self.__engine_launchers[engine_name]
+        return None
 
     def register_launch_commands(self):
         """

--- a/python/tk_multi_launchapp/prepare_apps.py
+++ b/python/tk_multi_launchapp/prepare_apps.py
@@ -54,6 +54,11 @@ def prepare_launch_for_engine(engine_name, app_path, app_args, context, file_to_
             # There's nothing left to do at this point, simply return
             # the resolved app_path and args values.
             return (launch_info.path, launch_info.args)
+        else:
+            tk_app.log_error(
+                "Engine %s does not support preparing application launches." %
+                engine_name
+            )
 
     except AttributeError:
         # Assuming 'create_engine_launcher' wasn't found in sgtk.platform

--- a/python/tk_multi_launchapp/prepare_apps.py
+++ b/python/tk_multi_launchapp/prepare_apps.py
@@ -39,86 +39,92 @@ def prepare_launch_for_engine(engine_name, app_path, app_args, context, file_to_
         launcher = sgtk.platform.create_engine_launcher(
             tk_app.sgtk, context, engine_name
         )
+        tk_app.log_debug("Created %s engine launcher : %s" %
+            (engine_name, launcher)
+        )
         if launcher:
-            launch_info = launcher.prepare_launch(app_path, app_args, None, file_to_open)
-            app_path = launch_info.path
-            app_args = launch_info.args
+            launch_info = launcher.prepare_launch(app_path, app_args, file_to_open)
             os.environ.update(launch_info.environment)
+            tk_app.log_debug(
+                "Engine launcher prepared launch info:\n  path : %s"
+                "\n  args : %s\n  env  : %s" % (launch_info.path,
+                launch_info.args, launch_info.environment)
+            )
+
+            # There's nothing left to do at this point, simply return
+            # the resolved app_path and args values.
+            return (launch_info.path, launch_info.args)
+
     except AttributeError:
         # Assuming 'create_engine_launcher' wasn't found in sgtk.platform
         # Fallback to use default behavior
-        launcher = None
-    except Exception, e:
-        # Something unexpected happened. Make a note of it and fall
-        # back on default behavior
-        tk_app.log_info("Caught Exception :\n%s" % e)
-        tk_app.log_info(
-            "Unable to use SoftwareLauncher for engine %s to prepare "
-            "DCC launch. Using launch app logic instead." % engine_name
+        tk_app.log_debug("'create_engine_launcher' method not found in sgtk.platform")
+
+    tk_app.log_debug(
+        "Using classic launchapp logic to prepare launch of '%s %s'" %
+        (app_path, app_args)
+    )
+
+    # we have an engine we should start as part of this app launch
+    # pass down the file to open into the startup script via env var.
+    if file_to_open:
+        os.environ["TANK_FILE_TO_OPEN"] = file_to_open
+        tk_app.log_debug("Setting TANK_FILE_TO_OPEN to '%s'" % file_to_open)
+
+    # serialize the context into an env var
+    os.environ["TANK_CONTEXT"] = sgtk.context.serialize(context)
+    tk_app.log_debug("Setting TANK_CONTEXT to '%r'" % context)
+
+    # Set environment variables used by apps to prep Tank engine
+    os.environ["TANK_ENGINE"] = engine_name
+
+    # Prep any application specific things now that we know we don't
+    # have an engine-specific bootstrap to use.
+    if engine_name == "tk-maya":
+        _prepare_maya_launch()
+    elif engine_name == "tk-softimage":
+        _prepare_softimage_launch()
+    elif engine_name == "tk-motionbuilder":
+        app_args = _prepare_motionbuilder_launch(app_args)
+    elif engine_name == "tk-3dsmax":
+        app_args = _prepare_3dsmax_launch(app_args)
+    elif engine_name == "tk-3dsmaxplus":
+        app_args = _prepare_3dsmaxplus_launch(context, app_args, app_path)
+    elif engine_name == "tk-photoshop":
+        _prepare_photoshop_launch(context)
+    elif engine_name == "tk-houdini":
+        _prepare_houdini_launch(context)
+    elif engine_name == "tk-mari":
+        _prepare_mari_launch(engine_name, context)
+    elif engine_name in ["tk-flame", "tk-flare"]:
+        (app_path, app_args) = _prepare_flame_flare_launch(
+            engine_name, context, app_path, app_args,
         )
-        launcher = None
-
-    if launcher is None:
-        # we have an engine we should start as part of this app launch
-        # pass down the file to open into the startup script via env var.
-        if file_to_open:
-            os.environ["TANK_FILE_TO_OPEN"] = file_to_open
-            tk_app.log_debug("Setting TANK_FILE_TO_OPEN to '%s'" % file_to_open)
-
-        # serialize the context into an env var
-        os.environ["TANK_CONTEXT"] = sgtk.context.serialize(context)
-        tk_app.log_debug("Setting TANK_CONTEXT to '%r'" % context)
-
-        # Set environment variables used by apps to prep Tank engine
-        os.environ["TANK_ENGINE"] = engine_name
-
-        # Prep any application specific things now that we know we don't
-        # have an engine-specific bootstrap to use.
-        if engine_name == "tk-maya":
-            _prepare_maya_launch()
-        elif engine_name == "tk-softimage":
-            _prepare_softimage_launch()
-        elif engine_name == "tk-motionbuilder":
-            app_args = _prepare_motionbuilder_launch(app_args)
-        elif engine_name == "tk-3dsmax":
-            app_args = _prepare_3dsmax_launch(app_args)
-        elif engine_name == "tk-3dsmaxplus":
-            app_args = _prepare_3dsmaxplus_launch(context, app_args, app_path)
-        elif engine_name == "tk-photoshop":
-            _prepare_photoshop_launch(context)
-        elif engine_name == "tk-houdini":
-            _prepare_houdini_launch(context)
-        elif engine_name == "tk-mari":
-            _prepare_mari_launch(engine_name, context)
-        elif engine_name in ["tk-flame", "tk-flare"]:
-            (app_path, app_args) = _prepare_flame_flare_launch(
-                engine_name, context, app_path, app_args,
+    else:
+        # This should really be the first thing we try, but some of
+        # the engines (like tk-3dsmaxplus, as an example) have bootstrapping
+        # logic that doesn't properly stand alone and still requires
+        # their "prepare" method here in launchapp to be run. As engines
+        # are updated to handle all their own bootstrapping, they can be
+        # pulled out from above and moved into the except block below in
+        # the way that tk-nuke and tk-hiero have.
+        try:
+            (app_path, app_args) = _prepare_generic_launch(
+                tk_app, engine_name, context, app_path, app_args,
             )
-        else:
-            # This should really be the first thing we try, but some of
-            # the engines (like tk-3dsmaxplus, as an example) have bootstrapping
-            # logic that doesn't properly stand alone and still requires
-            # their "prepare" method here in launchapp to be run. As engines
-            # are updated to handle all their own bootstrapping, they can be
-            # pulled out from above and moved into the except block below in
-            # the way that tk-nuke and tk-hiero have.
-            try:
-                (app_path, app_args) = _prepare_generic_launch(
-                    tk_app, engine_name, context, app_path, app_args,
+        except TankBootstrapNotFoundError:
+            # Backwards compatibility here for earlier engine versions.
+            if engine_name == "tk-nuke":
+                app_args = _prepare_nuke_launch(file_to_open, app_args)
+            elif engine_name == "tk-hiero":
+                _prepare_hiero_launch()
+            else:
+                # We have neither an engine-specific nor launchapp-specific
+                # bootstrap for this engine, so we have to bail out here.
+                raise TankError(
+                    "No bootstrap routine found for %s. The engine will not be started." %
+                    (engine_name)
                 )
-            except TankBootstrapNotFoundError:
-                # Backwards compatibility here for earlier engine versions.
-                if engine_name == "tk-nuke":
-                    app_args = _prepare_nuke_launch(file_to_open, app_args)
-                elif engine_name == "tk-hiero":
-                    _prepare_hiero_launch()
-                else:
-                    # We have neither an engine-specific nor launchapp-specific
-                    # bootstrap for this engine, so we have to bail out here.
-                    raise TankError(
-                        "No bootstrap routine found for %s. The engine will not be started." %
-                        (engine_name)
-                    )
 
     # Return resolved app path and args
     return (app_path, app_args)

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -159,7 +159,6 @@ class SoftwareEntityLauncher(BaseLauncher):
                     continue
 
             if "create_engine_launcher" in dir(sgtk.platform) and app_engine:
-                self._tk_app.log_info("Running new-fangled sgtk.platform.create_engine_launcher() ...")
                 self._register_software_version_commands(
                     app_menu_name, app_icon, app_engine, app_path, app_args, app_versions
                 )

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -37,7 +37,7 @@ class SoftwareEntityLauncher(BaseLauncher):
         app_args_field = "sg_%s_args" % self._platform_name
 
         # Collect a list of dictionaries that contain the information required
-        # to register a Toolkit command to launch the DCC.
+        # to register a command with the current engine to launch a DCC.
         register_cmds = []
         for sw_entity in sw_entities:
             self._tk_app.log_debug("Software Entity:\n%s" % pprint.pformat(sw_entity, indent=4))
@@ -190,14 +190,13 @@ class SoftwareEntityLauncher(BaseLauncher):
                 launcher = sgtk.platform.create_engine_launcher(
                     self._tk_app.sgtk, self._tk_app.context, engine
                 )
-                sw_versions = launcher.scan_software(versions, menu_name, icon)
-                for swv in sw_versions:
-                    commands.append(self._register_command_data(
-                        swv.display_name, swv.icon, engine, swv.path, args, swv.version
-                    ))
+                if launcher:
+                    sw_versions = launcher.scan_software(versions, menu_name, icon)
+                    for swv in sw_versions:
+                        commands.append(self._register_command_data(
+                            swv.display_name, swv.icon, engine, swv.path, args, swv.version
+                        ))
             except Exception, e:
-                # If no path has been set for the app, we will eventually go look for one,
-                # but for now, don't load the app.
                 self._tk_app.log_warning(
                     "Unable to determine path(s) for app [%s] from SoftwareLauncher "
                     "for engine %s. Exception raised :\n%s" %  (menu_name, engine, e)


### PR DESCRIPTION
Initial implementation for #38957 "auto detect maya paths" and #38959 "start up tk classic at maya app launch". Adds methods to that utilize SoftwareVersion and SoftwareLauncher instances generated through the new "create_engine_launcher()" method in tk-core to do all of the heavy-lifting to launch a DCC for a specified TK engine name.