### PR TITLE
For #39292, Support transparent Software entity icons

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -157,11 +157,11 @@ description: "Launch Applications and initialize the Shotgun Pipeline Toolkit."
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.14.0"
+requires_core_version: "v0.18.54"
 requires_engine_version:
 
 # the engines that this app can operate in:
 supported_engines: 
 
 frameworks:
-    - {"name": "tk-framework-shotgunutils", "version": "v4.x.x"}
+    - {"name": "tk-framework-shotgunutils", "version": "v5.x.x"}

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -52,8 +52,8 @@ class SoftwareEntityLauncher(BaseLauncher):
             # Download the thumbnail to use as the app's icon.
             app_icon = sw_entity["image"]
             if app_icon:
-                sg_icon = shotgun_data.ShotgunDataRetriever.download_thumbnail(
-                    app_icon, self._tk_app
+                sg_icon = shotgun_data.ShotgunDataRetriever.download_thumbnail_source(
+                    sw_entity["type"], sw_entity["id"], self._tk_app
                 )
                 app_icon = sg_icon
                 self._tk_app.log_debug("App icon from ShotgunDataRetriever : %s" % app_icon)

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -58,25 +58,9 @@ class SoftwareEntityLauncher(BaseLauncher):
                     shotgun_data = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_data")
                     # download thumbnail from shotgun
                     self._tk_app.log_debug("Download app icon...")
-                    try:
-                        # Download the thumbnail source file from Shotgun, which preserves
-                        # transparency and alpha values.
-                        local_thumb_path = shotgun_data.ShotgunDataRetriever.download_thumbnail_source(
-                            sw_entity["type"], sw_entity["id"], self._tk_app
-                        )
-
-                    except (TankError, AttributeError):
-                        # An old version of tk-framework-shotgunutils or tk-core is
-                        # likely in use. Try ShotgunDataRetriever.download_thumbnail() instead.
-                        self._tk_app.log_warning(
-                            "ShotgunDataRetriever is unable to download thumbnail source file. "
-                            "Attempting to download thumbnail instead. This issue may be "
-                            "resolved by updating local installations of tk-framework-shotgunutils "
-                            "and tk-core."
-                        )
-                        local_thumb_path = shotgun_data.ShotgunDataRetriever.download_thumbnail(
-                            sw_entity["image"], self._tk_app
-                        )
+                    local_thumb_path = shotgun_data.ShotgunDataRetriever.download_thumbnail_source(
+                        sw_entity["type"], sw_entity["id"], self._tk_app
+                    )
                     self._tk_app.log_debug("...download complete: %s" % local_thumb_path)
 
             app_engine = sw_entity["sg_engine"]

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -55,6 +55,27 @@ class SoftwareEntityLauncher(BaseLauncher):
                 sg_icon = shotgun_data.ShotgunDataRetriever.download_thumbnail_source(
                     sw_entity["type"], sw_entity["id"], self._tk_app
                 )
+
+                try:
+                    # Download the thumbnail source file from Shotgun, which preserves
+                    # transparency and alpha values.
+                    sg_icon = shotgun_data.ShotgunDataRetriever.download_thumbnail_source(
+                        sw_entity["type"], sw_entity["id"], self._tk_app
+                    )
+
+                except (TankError, AttributeError):
+                    # An old version of tk-framework-shotgunutils or tk-core is
+                    # likely in use. Try ShotgunDataRetriever.download_thumbnail() instead.
+                    self._tk_app.log_warning(
+                        "ShotgunDataRetriever is unable to download thumbnail source file. "
+                        "Attempting to download thumbnail instead. This issue may be "
+                        "resolved by updating local installations of tk-framework-shotgunutils "
+                        "and tk-core."
+                    )
+                    sg_icon = shotgun_data.ShotgunDataRetriever.download_thumbnail(
+                        sw_entity["image"], self._tk_app
+                    )
+
                 app_icon = sg_icon
                 self._tk_app.log_debug("App icon from ShotgunDataRetriever : %s" % app_icon)
 


### PR DESCRIPTION
Updates required to retrieve original source images uploaded for thumbnails. The primary reason for this update was to get the icons associated with Software entities to display with transparency in the project overlay widget of Desktop. The implementation attempts to handle older versions of tk-core and tk-framework-shotgunutils that may not have this feature implemented.