### PR TITLE
#40470 Update display and icon fallback logic

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -157,11 +157,11 @@ description: "Launch Applications and initialize the Shotgun Pipeline Toolkit."
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.14.0"
+requires_core_version: "v0.18.54"
 requires_engine_version:
 
 # the engines that this app can operate in:
 supported_engines: 
 
 frameworks:
-    - {"name": "tk-framework-shotgunutils", "version": "v4.x.x"}
+    - {"name": "tk-framework-shotgunutils", "version": "v5.x.x"}

--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -64,16 +64,10 @@ class BaseLauncher(object):
         icon = apply_version_to_setting(app_icon, version)
         menu_name = apply_version_to_setting(app_menu_name, version)
 
-        # Resolve the input path to the application to launch. Verify that
-        # it exists before creating a launch command.
+        # Resolve any env variables in the specified path to the application to launch.
         app_path = os.path.expandvars(
             apply_version_to_setting(app_path, version)
         )
-        if not os.path.exists(app_path):
-            self._tk_app.log_warning("%s application path [%s] does not exist!" %
-                (menu_name, app_path)
-            )
-            return
 
         # the command name mustn't contain spaces and funny chars, so sanitize it.
         # Also, should be nice for the shell engine.

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -47,22 +47,6 @@ class SoftwareEntityLauncher(BaseLauncher):
             ver_strings = [v.strip() for v in app_versions.split(",") if v.strip()]
             app_versions = ver_strings
 
-            # Download the thumbnail to use as the app's icon.
-            app_icon_url = sw_entity["image"]
-            # thumb will be none if it cannot be resolved for whatever reason
-            local_thumb_path = None
-            # now attempt to resolve a thumbnail path
-            if app_icon_url:
-                if self._tk_app.engine.has_ui:
-                    # import sgutils locally as this has dependencies on QT
-                    shotgun_data = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_data")
-                    # download thumbnail from shotgun
-                    self._tk_app.log_debug("Download app icon...")
-                    local_thumb_path = shotgun_data.ShotgunDataRetriever.download_thumbnail_source(
-                        sw_entity["type"], sw_entity["id"], self._tk_app
-                    )
-                    self._tk_app.log_debug("...download complete: %s" % local_thumb_path)
-
             app_engine = sw_entity["sg_engine"]
             if app_engine:
                 # Try to retrieve the path to the specified engine. If nothing is
@@ -86,7 +70,7 @@ class SoftwareEntityLauncher(BaseLauncher):
                 app_display_name, app_icon_url, app_engine, app_path, app_args, app_versions
             )
             for register_command in command_data:
-                if register_command["icon"] and self._tk_app.engine.has_ui:
+                if (register_command["icon"] == app_icon_url) and self._tk_app.engine.has_ui:
                     # import sgutils locally as this has dependencies on QT
                     shotgun_data = sgtk.platform.import_framework(
                         "tk-framework-shotgunutils", "shotgun_data"
@@ -97,7 +81,7 @@ class SoftwareEntityLauncher(BaseLauncher):
                         sw_entity["type"], sw_entity["id"], self._tk_app
                     )
                     self._tk_app.log_debug("...download complete: %s" % local_thumb_path)
-                    register_command["icon] = local_thumb_path
+                    register_command["icon"] = local_thumb_path
 
                 register_cmd_data.append(register_command)
 

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -52,8 +52,8 @@ class SoftwareEntityLauncher(BaseLauncher):
             # Download the thumbnail to use as the app's icon.
             app_icon = sw_entity["image"]
             if app_icon:
-                sg_icon = shotgun_data.ShotgunDataRetriever.download_thumbnail(
-                    app_icon, self._tk_app
+                sg_icon = shotgun_data.ShotgunDataRetriever.download_thumbnail_source(
+                    sw_entity["type"], sw_entity["id"], self._tk_app
                 )
                 app_icon = sg_icon
                 self._tk_app.log_debug("App icon from ShotgunDataRetriever : %s" % app_icon)

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -66,10 +66,15 @@ class SoftwareEntityLauncher(BaseLauncher):
             app_display_name = sw_entity["code"]
             app_args = sw_entity[app_args_field] or ""
             app_icon_url = sw_entity["image"]
+
+            # Get the list of command data dictionaries from the information
+            # provided by this Software entity
             command_data = self._build_register_command_data(
                 app_display_name, app_icon_url, app_engine, app_path, app_args, app_versions
             )
             for register_command in command_data:
+                # If the Software entity icon is being used for the command, download and
+                # cache it if possible.
                 if (register_command["icon"] == app_icon_url) and self._tk_app.engine.has_ui:
                     # import sgutils locally as this has dependencies on QT
                     shotgun_data = sgtk.platform.import_framework(
@@ -84,7 +89,6 @@ class SoftwareEntityLauncher(BaseLauncher):
                     register_command["icon"] = local_thumb_path
 
                 register_cmd_data.append(register_command)
-
 
         registered_cmds = []
         for register_cmd in register_cmd_data:

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -257,14 +257,14 @@ class SoftwareEntityLauncher(BaseLauncher):
             # retrieve the icon from the associated Toolkit engine launcher and use that instead.
             download_icon = True if icon else False
             if not icon and engine:
-                sw_versions = self._engine_launcher_software_versions(
+                software_versions = self._scan_for_software(
                     engine, display_name, icon, versions
                 )
-                if sw_versions:
+                if software_versions:
                     self._tk_app.log_debug("Using icon %s from SoftwareVersion for %s." %
-                        ((sw_versions[0].icon), display_name)
+                        ((software_versions[0].icon), display_name)
                     )
-                    icon = sw_versions[0].icon
+                    icon = software_versions[0].icon
                 else:
                     self._tk_app.log_debug("No SoftwareVersions found for Toolkit engine %s. "
                         "Cannot determine icon to display for %s." % (engine, display_name)
@@ -295,20 +295,20 @@ class SoftwareEntityLauncher(BaseLauncher):
             self._tk_app.log_debug("Using %s engine launcher to find application paths for %s." %
                 (engine, display_name)
             )
-            sw_versions = self._engine_launcher_software_versions(
+            software_versions = self._scan_for_software(
                 engine, display_name, icon, versions
             ) or []
-            for swv in sw_versions:
+            for software_version in software_versions:
                 # Construct a command for each SoftwareVersion found.
                 commands.append({
-                    "display_name": swv.display_name, "icon": swv.icon,
-                    "engine": engine, "path": swv.path, "args": args,
-                    "version": swv.version
+                    "display_name": software_version.display_name, "icon": software_version.icon,
+                    "engine": engine, "path": software_version.path, "args": args,
+                    "version": software_version.version
                 })
 
                 # If the resolved SoftwareVersion icon is empty or does not exist
                 # locally, use the Software icon instead.
-                if not swv.icon or not os.path.exists(swv.icon):
+                if not software_version.icon or not os.path.exists(software_version.icon):
                     download_icon_for_commands.append(command_data)
 
         else:
@@ -348,7 +348,7 @@ class SoftwareEntityLauncher(BaseLauncher):
 
         return commands
 
-    def _engine_launcher_software_versions(self, engine, default_name, default_icon, versions=None):
+    def _scan_for_software(self, engine, default_name, default_icon, versions=None):
         """
         Use the "auto discovery" feature of an engine launcher to scan the local environment
         for all related application paths. This information will in turn be used to construct
@@ -367,7 +367,7 @@ class SoftwareEntityLauncher(BaseLauncher):
         :returns: List of SoftwareVersions related to the specified engine that meet the input
                   requirements / restrictions.
         """
-        sw_versions = []
+        software_versions = []
         # First try to construct the engine launcher for the specified engine.
         try:
             self._tk_app.log_debug("Initializing engine launcher for %s." % engine)
@@ -390,7 +390,7 @@ class SoftwareEntityLauncher(BaseLauncher):
         # Next try to scan for available applications for this engine.
         try:
             self._tk_app.log_debug("Scanning for Toolkit engine %s local applications." % engine)
-            sw_versions = engine_launcher.scan_software(versions, default_name, default_icon)
+            software_versions = engine_launcher.scan_software(versions, default_name, default_icon)
         except Exception, e:
             self._tk_app.log_warning(
                 "Caught unexpected error scanning for DCC applications corresponding "
@@ -398,4 +398,4 @@ class SoftwareEntityLauncher(BaseLauncher):
             )
             return None
 
-        return sw_versions
+        return software_versions

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -58,25 +58,9 @@ class SoftwareEntityLauncher(BaseLauncher):
                     shotgun_data = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_data")
                     # download thumbnail from shotgun
                     self._tk_app.log_debug("Download app icon...")
-                    try:
-                        # Download the thumbnail source file from Shotgun, which preserves
-                        # transparency and alpha values.
-                        local_thumb_path = shotgun_data.ShotgunDataRetriever.download_thumbnail_source(
-                            sw_entity["type"], sw_entity["id"], self._tk_app
-                        )
-
-                    except (TankError, AttributeError):
-                        # An old version of tk-framework-shotgunutils or tk-core is
-                        # likely in use. Try ShotgunDataRetriever.download_thumbnail() instead.
-                        self._tk_app.log_warning(
-                            "ShotgunDataRetriever is unable to download thumbnail source file. "
-                            "Attempting to download thumbnail instead. This issue may be "
-                            "resolved by updating local installations of tk-framework-shotgunutils "
-                            "and tk-core."
-                        )
-                        local_thumb_path = shotgun_data.ShotgunDataRetriever.download_thumbnail(
-                            sw_entity["image"], self._tk_app
-                        )
+                    local_thumb_path = shotgun_data.ShotgunDataRetriever.download_thumbnail_source(
+                        sw_entity["type"], sw_entity["id"], self._tk_app
+                    )
                     self._tk_app.log_debug("...download complete: %s" % local_thumb_path)
 
             app_engine = sw_entity["sg_engine"]

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -55,6 +55,27 @@ class SoftwareEntityLauncher(BaseLauncher):
                 sg_icon = shotgun_data.ShotgunDataRetriever.download_thumbnail_source(
                     sw_entity["type"], sw_entity["id"], self._tk_app
                 )
+
+                try:
+                    # Download the thumbnail source file from Shotgun, which preserves
+                    # transparency and alpha values.
+                    sg_icon = shotgun_data.ShotgunDataRetriever.download_thumbnail_source(
+                        sw_entity["type"], sw_entity["id"], self._tk_app
+                    )
+
+                except (TankError, AttributeError):
+                    # An old version of tk-framework-shotgunutils or tk-core is
+                    # likely in use. Try ShotgunDataRetriever.download_thumbnail() instead.
+                    self._tk_app.log_warning(
+                        "ShotgunDataRetriever is unable to download thumbnail source file. "
+                        "Attempting to download thumbnail instead. This issue may be "
+                        "resolved by updating local installations of tk-framework-shotgunutils "
+                        "and tk-core."
+                    )
+                    sg_icon = shotgun_data.ShotgunDataRetriever.download_thumbnail(
+                        sw_entity["image"], self._tk_app
+                    )
+
                 app_icon = sg_icon
                 self._tk_app.log_debug("App icon from ShotgunDataRetriever : %s" % app_icon)
 


### PR DESCRIPTION
Updates the logic in the `SoftwareEntityLauncher` class to handle icons and display names that may be overridden by `SoftwareVersion` instances returned from the engine's `scan_software()` method. Only attempt to download and cache thumbnail files retrieved from an SG Software entity.