### PR TITLE
#40549 Implement registered command grouping

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -86,8 +86,7 @@ configuration:
 
     group:
         type: str
-        description: "The name for a group this command should be considered a member of. This value
-                      is ultimately interpreted by the engine the command is registered with."
+        description: "The name for a group this command should be considered a member of."
         default_value: ""
 
     group_default:

--- a/info.yml
+++ b/info.yml
@@ -84,6 +84,19 @@ configuration:
                       you can launch applications that do not have toolkit engines set up."
         default_value: ""
 
+    group:
+        type: str
+        description: "The name for a group this command should be considered a member of. This value
+                      is ultimately interpreted by the engine the command is registered with."
+        default_value: ""
+
+    group_default:
+        type: bool
+        description: "Boolean value indicating whether this command should represent the group as
+                      a whole. Setting this value to True indicates that this is the command to run and
+                      display in applications that show a single button for each named group."
+        default_value: False
+
     defer_keyword:
         type: str
         default_value: ""

--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -45,7 +45,8 @@ class BaseLauncher(object):
             app_engine,
             app_path,
             app_args,
-            version=None
+            version=None,
+            properties=None,
         ):
         """
         Register a launch command with the current engine.
@@ -88,12 +89,15 @@ class BaseLauncher(object):
             "shotgun_version",
         ]
         if self._tk_app.engine.environment.get("name") not in skip_environments:
-            properties = {
+            if not properties:
+                properties = {}
+
+            properties.update({
                 "title": menu_name,
                 "short_name": command_name,
                 "description": "Launches and initializes an application environment.",
                 "icon": icon,
-            }
+            })
 
             def launch_version():
                 self._launch_callback(

--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -13,6 +13,7 @@ import sys
 
 import sgtk
 from sgtk import TankError
+from sgtk.deploy import util
 
 from .util import apply_version_to_setting, get_clean_version_string
 from .util import clear_dll_directory, restore_dll_directory

--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -348,10 +348,10 @@ class BaseLauncher(object):
 
     def _sort_versions(self, versions):
         """
-        Uses standard python modules to determine how to sort arbitrary version numbers. A version
-        number consists of a series of numbers, separated by either periods or strings of letters.
-        When comparing version numbers, the numeric components will be compared numerically, and
-        the alphabetic components lexically. For example:
+        Uses standard python modules to determine how to sort arbitrary version numbers.
+        A version number consists of a series of numbers, separated by either periods or
+        strings of letters. When comparing version numbers, the numeric components will
+        be compared numerically, and the alphabetic components lexically. For example:
 
             1.1 < 1.2 < 1.3
             1.2 < 1.2a < 1.2ab < 1.2b
@@ -359,12 +359,13 @@ class BaseLauncher(object):
         The input list of versions is not modified.
 
         :param list versions: List of version "numbers" (may be strings)
-        :returns: List of sorted versions
+        :returns: List of sorted versions in descending order. The highest version is
+                  at index 0.
         """
         # Cast the incoming version strings as LooseVersion instances to sort using
         # the LooseVersion.__cmp__ method.
         sort_versions = [LooseVersion(version) for version in versions]
-        sort_versions.sort()
+        sort_versions.sort(reverse=True)
 
         # Convert the LooseVersions back to strings on return.
         return [str(version) for version in sort_versions]

--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -64,10 +64,10 @@ class BaseLauncher(object):
         :param str version: (Optional) Specific version of DCC to use.
         :param str group: (Optional) Group name this command belongs to. This value is
                           interpreted by the engine the command is registered with.
-        :param bool group_default: (Optional) If this command is one of a group of commands, 
-                                   indicate whether to launch this command if the group is 
-                                   selected instead of an individual command.  Again, this
-                                   value is interpreted by the engine the command is registered with.
+        :param bool group_default: (Optional) If this command is one of a group of commands,
+                                   indicate whether to launch this command if the group is
+                                   selected instead of an individual command. This value is
+                                   also interpreted by the engine the command is registered with.
         """
         # do the {version} replacement if needed
         icon = apply_version_to_setting(app_icon, version)
@@ -345,4 +345,32 @@ class BaseLauncher(object):
         :param version: (Optional) Specific version of DCC to launch.
         """
         raise NotImplementedError
+
+    def _sort_versions(self, versions):
+        """
+        Uses standard python modules to determine how to sort arbitrary version numbers. A version
+        number consists of a series of numbers, separated by either periods or strings of letters.
+        When comparing version numbers, the numeric components will be compared numerically, and
+        the alphabetic components lexically. For example:
+
+            1.1 < 1.2 < 1.3
+            1.2 < 1.2a < 1.2ab < 1.2b
+
+        This methodology is also used in Desktop. The input list of versions is not modified.
+
+        :param list versions: List of version "numbers" (may be strings)
+        :returns: List of sorted versions
+        """
+        # Do not sort the incoming versions in place.
+        sort_versions = [version for version in versions]
+
+        def version_cmp(left_version, right_version):
+            if util.is_version_newer(left_version, right_version):
+                return -1
+            if util.is_version_older(left_version, right_version):
+                return 1
+            return 0
+
+        sort_versions.sort(cmp=version_cmp)
+        return sort_versions
 

--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -338,3 +338,35 @@ class BaseLauncher(object):
         :param version: (Optional) Specific version of DCC to launch.
         """
         raise NotImplementedError
+
+
+    def _get_group_name(self, engine):
+        """
+        Construct a group name from an engine name. This name will be used to group
+        like commands together when registering commands with the current engine.
+
+        :param str engine: Toolkit engine name that the launch commands are associated with.
+        :returns: String group name or None
+        """
+        return engine.split("-")[-1].capitalize() if engine else None
+
+    def _sort_group_versions(self, versions):
+        """
+        Controls how version numbers are sorted. Implements the same methodology as Desktop.
+        Does not modify the input list of versions.
+
+        :param list versions: List of version "numbers" (may be strings)
+        :returns: List of sorted versions
+        """
+        # Do not sort the incoming versions in place.
+        sort_versions = [version for version in versions]
+
+        def version_cmp(left_version, right_version):
+            if util.is_version_newer(left_version, right_version):
+                return -1
+            if util.is_version_older(left_version, right_version):
+                return 1
+            return 0
+
+        sort_versions.sort(cmp=version_cmp)
+        return sort_versions

--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -10,10 +10,10 @@
 
 import os
 import sys
+from distutils.version import LooseVersion
 
 import sgtk
 from sgtk import TankError
-from sgtk.deploy import util
 
 from .util import apply_version_to_setting, get_clean_version_string
 from .util import clear_dll_directory, restore_dll_directory
@@ -356,21 +356,16 @@ class BaseLauncher(object):
             1.1 < 1.2 < 1.3
             1.2 < 1.2a < 1.2ab < 1.2b
 
-        This methodology is also used in Desktop. The input list of versions is not modified.
+        The input list of versions is not modified.
 
         :param list versions: List of version "numbers" (may be strings)
         :returns: List of sorted versions
         """
-        # Do not sort the incoming versions in place.
-        sort_versions = [version for version in versions]
+        # Cast the incoming version strings as LooseVersion instances to sort using
+        # the LooseVersion.__cmp__ method.
+        sort_versions = [LooseVersion(version) for version in versions]
+        sort_versions.sort()
 
-        def version_cmp(left_version, right_version):
-            if util.is_version_newer(left_version, right_version):
-                return -1
-            if util.is_version_older(left_version, right_version):
-                return 1
-            return 0
-
-        sort_versions.sort(cmp=version_cmp)
-        return sort_versions
+        # Convert the LooseVersions back to strings on return.
+        return [str(version) for version in sort_versions]
 

--- a/python/tk_multi_launchapp/single_config_launcher.py
+++ b/python/tk_multi_launchapp/single_config_launcher.py
@@ -74,6 +74,7 @@ class SingleConfigLauncher(BaseLauncher):
         # Initialize per version
         app_versions = self._tk_app.get_setting("versions") or []
         if app_versions:
+            # Information used to construct the equivalent of Desktop "collapse rules"
             group_name = self._get_group_name(self._app_engine)
             sorted_versions = self._sort_group_versions(app_versions)
 

--- a/python/tk_multi_launchapp/single_config_launcher.py
+++ b/python/tk_multi_launchapp/single_config_launcher.py
@@ -80,6 +80,14 @@ class SingleConfigLauncher(BaseLauncher):
             # setting is invalid because it cannot be applied to each generated command.
             # Set the group default to the highest version in the list instead.
             sorted_versions = self._sort_versions(app_versions)
+            self._tk_app.log_warning(
+                "Unable to apply 'group_default' value to list of DCC versions : %s" %
+                app_versions
+            )
+            self._tk_app.log_warning(
+                "Setting group '%s' default to highest version '%s' instead." %
+                (self._app_group, sorted_versions[0])
+            )
 
             for version in app_versions:
                 self._register_launch_command(

--- a/python/tk_multi_launchapp/single_config_launcher.py
+++ b/python/tk_multi_launchapp/single_config_launcher.py
@@ -74,10 +74,18 @@ class SingleConfigLauncher(BaseLauncher):
         # Initialize per version
         app_versions = self._tk_app.get_setting("versions") or []
         if app_versions:
+            group_name = self._get_group_name(self._app_engine)
+            sorted_versions = self._sort_group_versions(app_versions)
+
             for version in app_versions:
+                properties = {
+                    "group": group_name,
+                    "group_default": (version == sorted_versions[0])
+                } if group_name else None
+
                 self._register_launch_command(
                     self._app_menu_name, app_icon, self._app_engine,
-                    self._app_path, self._app_args, version
+                    self._app_path, self._app_args, version, properties,
                 )
         else:
             # No replacements defined, just register with the raw values

--- a/python/tk_multi_launchapp/single_config_launcher.py
+++ b/python/tk_multi_launchapp/single_config_launcher.py
@@ -81,12 +81,9 @@ class SingleConfigLauncher(BaseLauncher):
             # Set the group default to the highest version in the list instead.
             sorted_versions = self._sort_versions(app_versions)
             self._tk_app.log_warning(
-                "Unable to apply 'group_default' value to list of DCC versions : %s" %
-                app_versions
-            )
-            self._tk_app.log_warning(
+                "Unable to apply group '%s' group_default value to list of DCC versions : %s. "
                 "Setting group '%s' default to highest version '%s' instead." %
-                (self._app_group, sorted_versions[0])
+                (self._app_group, sorted_versions, self._app_group, sorted_versions[0])
             )
 
             for version in app_versions:

--- a/python/tk_multi_launchapp/single_config_launcher.py
+++ b/python/tk_multi_launchapp/single_config_launcher.py
@@ -30,6 +30,8 @@ class SingleConfigLauncher(BaseLauncher):
         self._app_args = self._tk_app.get_setting("%s_args" % self._platform_name, "")
         self._app_menu_name = self._tk_app.get_setting("menu_name")
         self._app_engine = self._tk_app.get_setting("engine")
+        self._app_group = self._tk_app.get_setting("group")
+        self._is_group_default = self._tk_app.get_setting("group_default")
 
     def register_launch_commands(self):
         """
@@ -74,6 +76,11 @@ class SingleConfigLauncher(BaseLauncher):
         # Initialize per version
         app_versions = self._tk_app.get_setting("versions") or []
         if app_versions:
+            # If a list of versions has been specified, the "group_default" configuration
+            # setting is invalid because it cannot be applied to each generated command.
+            # Set the group default to the highest version in the list instead.
+            sorted_versions = self._sort_versions(app_versions)
+
             for version in app_versions:
                 self._register_launch_command(
                     self._app_menu_name,
@@ -82,6 +89,8 @@ class SingleConfigLauncher(BaseLauncher):
                     self._app_path,
                     self._app_args,
                     version,
+                    self._app_group,
+                    (version == sorted_versions[0])
                 )
         else:
             # No replacements defined, just register with the raw values
@@ -90,7 +99,10 @@ class SingleConfigLauncher(BaseLauncher):
                 app_icon,
                 self._app_engine,
                 self._app_path,
-                self._app_args
+                self._app_args,
+                None,
+                self._app_group,
+                self._is_group_default,
             )
 
     def launch_from_path(self, path, version=None):

--- a/python/tk_multi_launchapp/single_config_launcher.py
+++ b/python/tk_multi_launchapp/single_config_launcher.py
@@ -74,25 +74,23 @@ class SingleConfigLauncher(BaseLauncher):
         # Initialize per version
         app_versions = self._tk_app.get_setting("versions") or []
         if app_versions:
-            # Information used to construct the equivalent of Desktop "collapse rules"
-            group_name = self._get_group_name(self._app_engine)
-            sorted_versions = self._sort_group_versions(app_versions)
-
             for version in app_versions:
-                properties = {
-                    "group": group_name,
-                    "group_default": (version == sorted_versions[0])
-                } if group_name else None
-
                 self._register_launch_command(
-                    self._app_menu_name, app_icon, self._app_engine,
-                    self._app_path, self._app_args, version, properties,
+                    self._app_menu_name,
+                    app_icon,
+                    self._app_engine,
+                    self._app_path,
+                    self._app_args,
+                    version,
                 )
         else:
             # No replacements defined, just register with the raw values
             self._register_launch_command(
-                self._app_menu_name, app_icon, self._app_engine,
-                self._app_path, self._app_args
+                self._app_menu_name,
+                app_icon,
+                self._app_engine,
+                self._app_path,
+                self._app_args
             )
 
     def launch_from_path(self, path, version=None):

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -11,7 +11,6 @@ import os
 import pprint
 
 import sgtk
-from sgtk.deploy import util
 
 from .base_launcher import BaseLauncher
 

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -272,6 +272,7 @@ class SoftwareEntityLauncher(BaseLauncher):
                     )
 
             if versions:
+                # Information used to construct the equivalent of Desktop "collapse rules"
                 group_name = self._get_group_name(engine)
                 sorted_versions = self._sort_group_versions(versions)
 
@@ -308,18 +309,17 @@ class SoftwareEntityLauncher(BaseLauncher):
                 engine, display_name, icon, versions
             ) or []
 
-            # Sort the returned version "numbers"
+            # Information used to construct the equivalent of Desktop "collapse rules"
             group_name = self._get_group_name(engine)
             sorted_versions = self._sort_group_versions(
                 [software_version.version for software_version in software_versions]
             )
 
             for software_version in software_versions:
-                # Construct the equivalent of Desktop "collapse rules"
                 properties = {
                     "group": group_name,
                     "group_default": (software_version.version == sorted_versions[0])
-                }
+                } if group_name else None
 
                 # Construct a command for each SoftwareVersion found.
                 commands.append({

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -89,7 +89,7 @@ class SoftwareEntityLauncher(BaseLauncher):
                 register_cmd["path"],
                 register_cmd["args"],
                 register_cmd["version"],
-                register_cmd.get("properties") or None
+                register_cmd.get("properties")
             )
 
     def launch_from_path(self, path, version=None):

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -288,6 +288,15 @@ class SoftwareEntityLauncher(BaseLauncher):
                 # be generated from a single Software entity. Set the group default to the
                 # highest version in the list.
                 sorted_versions = self._sort_versions(versions)
+                self._tk_app.log_warning(
+                    "Unable to apply 'group_default' value to list of DCC versions : %s" %
+                    versions
+                )
+                self._tk_app.log_warning(
+                    "Setting group '%s' default to highest version '%s' instead." %
+                    (group, sorted_versions[0])
+                )
+
                 for version in versions:
                     commands.append({
                         "display_name": display_name,
@@ -332,6 +341,14 @@ class SoftwareEntityLauncher(BaseLauncher):
             # Set the group default to the highest version in the list in this case as well.
             sorted_versions = self._sort_versions(
                 [software_version.version for software_version in software_versions]
+            )
+            self._tk_app.log_warning(
+                "Unable to apply 'group_default' value to list of DCC versions : %s" %
+                sorted_versions
+            )
+            self._tk_app.log_warning(
+                "Setting group '%s' default to highest version '%s' instead." %
+                (group, sorted_versions[0])
             )
 
             for software_version in software_versions:

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -277,20 +277,20 @@ class SoftwareEntityLauncher(BaseLauncher):
 
                 # Construct a command for each version.
                 for version in versions:
-                    extra_properties = {
+                    properties = {
                         "group": group_name,
                         "group_default": (version == sorted_versions[0])
                     } if group_name else None
 
                     commands.append({
                         "display_name": display_name, "icon": icon, "engine": engine,
-                        "path": path, "args": args, "version": version, "properties": extra_properties
+                        "path": path, "args": args, "version": version, "properties": properties
                     })
             else:
                 # Construct a single, version-less command.
                 commands.append({
                     "display_name": display_name, "icon": icon, "engine": engine,
-                    "path": path, "args": args, "version": None, "properties": None,
+                    "path": path, "args": args, "version": None,
                 })
 
             if download_icon:
@@ -316,7 +316,7 @@ class SoftwareEntityLauncher(BaseLauncher):
 
             for software_version in software_versions:
                 # Construct the equivalent of Desktop "collapse rules"
-                extra_properties = {
+                properties = {
                     "group": group_name,
                     "group_default": (software_version.version == sorted_versions[0])
                 }
@@ -325,7 +325,7 @@ class SoftwareEntityLauncher(BaseLauncher):
                 commands.append({
                     "display_name": software_version.display_name, "icon": software_version.icon,
                     "engine": engine, "path": software_version.path, "args": args,
-                    "version": software_version.version, "properties": extra_properties,
+                    "version": software_version.version, "properties": properties,
                 })
 
                 # If the resolved SoftwareVersion icon is empty or does not exist
@@ -421,4 +421,3 @@ class SoftwareEntityLauncher(BaseLauncher):
             return None
 
         return software_versions
-

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -89,7 +89,8 @@ class SoftwareEntityLauncher(BaseLauncher):
                 register_cmd["path"],
                 register_cmd["args"],
                 register_cmd["version"],
-                register_cmd.get("properties")
+                register_cmd["group"],
+                register_cmd["group_default"],
             )
 
     def launch_from_path(self, path, version=None):
@@ -272,26 +273,24 @@ class SoftwareEntityLauncher(BaseLauncher):
                     )
 
             if versions:
-                # Information used to construct the equivalent of Desktop "collapse rules"
-                group_name = self._get_group_name(engine)
-                sorted_versions = self._sort_group_versions(versions)
-
                 # Construct a command for each version.
                 for version in versions:
-                    properties = {
-                        "group": group_name,
-                        "group_default": (version == sorted_versions[0])
-                    } if group_name else None
-
                     commands.append({
-                        "display_name": display_name, "icon": icon, "engine": engine,
-                        "path": path, "args": args, "version": version, "properties": properties
+                        "display_name": display_name,
+                        "icon": icon,
+                        "engine": engine,
+                        "path": path,
+                        "args": args,
+                        "version": version,
                     })
             else:
                 # Construct a single, version-less command.
                 commands.append({
-                    "display_name": display_name, "icon": icon, "engine": engine,
-                    "path": path, "args": args, "version": None,
+                    "display_name": display_name,
+                    "icon": icon,
+                    "engine": engine,
+                    "path": path,
+                    "args": args,
                 })
 
             if download_icon:
@@ -309,23 +308,18 @@ class SoftwareEntityLauncher(BaseLauncher):
                 engine, display_name, icon, versions
             ) or []
 
-            # Information used to construct the equivalent of Desktop "collapse rules"
-            group_name = self._get_group_name(engine)
-            sorted_versions = self._sort_group_versions(
-                [software_version.version for software_version in software_versions]
-            )
-
             for software_version in software_versions:
-                properties = {
-                    "group": group_name,
-                    "group_default": (software_version.version == sorted_versions[0])
-                } if group_name else None
-
                 # Construct a command for each SoftwareVersion found.
                 commands.append({
-                    "display_name": software_version.display_name, "icon": software_version.icon,
-                    "engine": engine, "path": software_version.path, "args": args,
-                    "version": software_version.version, "properties": properties,
+                    "display_name": software_version.display_name,
+                    "icon": software_version.icon,
+                    "engine": engine,
+                    "path": software_version.path,
+                    "args": args,
+                    "version": software_version.version,
+                    "properties": properties,
+                    "group": software_version.group,
+                    "group_default": software_version.group_default,
                 })
 
                 # If the resolved SoftwareVersion icon is empty or does not exist

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -273,8 +273,8 @@ class SoftwareEntityLauncher(BaseLauncher):
                     )
 
             if versions:
-                group_name = engine.split("-")[-1].capitalize() if engine else None
-                sorted_versions = self._sort_versions(versions)
+                group_name = self._get_group_name(engine)
+                sorted_versions = self._sort_group_versions(versions)
 
                 # Construct a command for each version.
                 for version in versions:
@@ -310,8 +310,8 @@ class SoftwareEntityLauncher(BaseLauncher):
             ) or []
 
             # Sort the returned version "numbers"
-            group_name = engine.split("-")[-1].capitalize()
-            sorted_versions = self._sort_versions(
+            group_name = self._get_group_name(engine)
+            sorted_versions = self._sort_group_versions(
                 [software_version.version for software_version in software_versions]
             )
 
@@ -423,23 +423,3 @@ class SoftwareEntityLauncher(BaseLauncher):
 
         return software_versions
 
-    def _sort_versions(self, versions):
-        """
-        Controls how version numbers are sorted. Implements the same methodology as Desktop.
-        Does not modify the input list of versions.
-
-        :param list versions: List of version "numbers" (may be strings)
-        :returns: List of sorted versions
-        """
-        # Do not sort the incoming versions in place.
-        sort_versions = [version for version in versions]
-
-        def version_cmp(left_version, right_version):
-            if util.is_version_newer(left_version, right_version):
-                return -1
-            if util.is_version_older(left_version, right_version):
-                return 1
-            return 0
-
-        sort_versions.sort(cmp=version_cmp)
-        return sort_versions


### PR DESCRIPTION
Implementation to determine "group" and "group_default" values to send through the properties dictionary when registering a command with the current Toolkit engine.  If a list of versions is resolved for a launch command, the group name is derived from the associated engine and group_default will be set to True for the latest version number and False for all others. The grouping mechanism is not triggered for version-less launch commands.