### PR TITLE
#40550 Adds new field Products to allow product filtering

### DIFF
--- a/hooks/app_launch.py
+++ b/hooks/app_launch.py
@@ -50,8 +50,11 @@ class AppLaunch(tank.Hook):
             # on the mac, the executable paths are normally pointing
             # to the application bundle and not to the binary file
             # embedded in the bundle, meaning that we should use the
-            # built-in mac open command to execute it
-            cmd = "open -n \"%s\"" % (app_path)
+            # built-in mac open command to execute it. The -n flag tells the OS
+            # to launch a new instance even if one is already running. The -a
+            # flag specifies that the path is an application and supports both
+            # the app bundle form or the full executable form.
+            cmd = "open -n -a \"%s\"" % (app_path)
             if app_args:
                 cmd += " --args \"%s\"" % app_args.replace("\"", "\\\"")
         

--- a/python/tk_multi_launchapp/prepare_apps.py
+++ b/python/tk_multi_launchapp/prepare_apps.py
@@ -14,6 +14,7 @@ import sys
 import sgtk
 from sgtk import TankError
 
+
 def prepare_launch_for_engine(engine_name, app_path, app_args, context, file_to_open=None):
     """
     Prepares the environment to launch a DCC application in for the
@@ -32,23 +33,24 @@ def prepare_launch_for_engine(engine_name, app_path, app_args, context, file_to_
     # Retrieve the TK Application instance from the current bundle
     tk_app = sgtk.platform.current_bundle()
 
-    try:
-        # Try to use the TK engine to perform the necessary preparations
+    # Make sure this version of core supports the create_engine_launcher method, this was introduced
+    # very recently, but we don't want to lock bugfixes to the legacy launch system behind a core upgrade.
+    if hasattr(sgtk.platform, "create_engine_launcher"):
+        # Use the TK engine to perform the necessary preparations
         # to launch the DCC. If launcher is None, then chances are the
         # installed version of the specified engine isn't up-to-date.
         launcher = sgtk.platform.create_engine_launcher(
             tk_app.sgtk, context, engine_name
         )
-        tk_app.log_debug("Created %s engine launcher : %s" %
-            (engine_name, launcher)
-        )
         if launcher:
+            tk_app.log_debug("Created %s engine launcher : %s" % (engine_name, launcher))
             launch_info = launcher.prepare_launch(app_path, app_args, file_to_open)
             os.environ.update(launch_info.environment)
             tk_app.log_debug(
                 "Engine launcher prepared launch info:\n  path : %s"
-                "\n  args : %s\n  env  : %s" % (launch_info.path,
-                launch_info.args, launch_info.environment)
+                "\n  args : %s\n  env  : %s" % (
+                    launch_info.path, launch_info.args, launch_info.environment
+                )
             )
 
             # There's nothing left to do at this point, simply return
@@ -59,10 +61,7 @@ def prepare_launch_for_engine(engine_name, app_path, app_args, context, file_to_
                 "Engine %s does not support preparing application launches." %
                 engine_name
             )
-
-    except AttributeError:
-        # Assuming 'create_engine_launcher' wasn't found in sgtk.platform
-        # Fallback to use default behavior
+    else:
         tk_app.log_debug("'create_engine_launcher' method not found in sgtk.platform")
 
     tk_app.log_debug(
@@ -134,6 +133,7 @@ def prepare_launch_for_engine(engine_name, app_path, app_args, context, file_to_
     # Return resolved app path and args
     return (app_path, app_args)
 
+
 def _prepare_generic_launch(tk_app, engine_name, context, app_path, app_args):
     """
     Generic engine launcher.
@@ -202,6 +202,7 @@ def _prepare_generic_launch(tk_app, engine_name, context, app_path, app_args):
 
     return (app_path, new_args)
 
+
 def _prepare_nuke_launch(file_to_open, app_args):
     """
     Nuke specific pre-launch environment setup.
@@ -226,12 +227,14 @@ def _prepare_nuke_launch(file_to_open, app_args):
 
     return app_args
 
+
 def _prepare_hiero_launch():
     """
     Hiero specific pre-launch environment setup.
     """
     startup_path = _get_app_startup_path("hiero")
     sgtk.util.append_path_to_env_var("HIERO_PLUGIN_PATH", startup_path)
+
 
 def _prepare_maya_launch():
     """
@@ -240,6 +243,7 @@ def _prepare_maya_launch():
     # Make sure Maya can find the Tank menu
     startup_path = _get_app_startup_path("maya")
     sgtk.util.append_path_to_env_var("PYTHONPATH", startup_path)
+
 
 def _prepare_softimage_launch():
     """
@@ -267,6 +271,7 @@ def _prepare_softimage_launch():
         sgtk.util.append_path_to_env_var("LD_LIBRARY_PATH", lib_path)
         sgtk.util.append_path_to_env_var("PYTHONPATH", lib_path)
 
+
 def _prepare_motionbuilder_launch(app_args):
     """
     Motionbuilder specific pre-launch environment setup.
@@ -284,6 +289,7 @@ def _prepare_motionbuilder_launch(app_args):
         app_args = new_args
 
     return app_args
+
 
 def _prepare_3dsmax_launch(app_args):
     """
@@ -305,6 +311,7 @@ def _prepare_3dsmax_launch(app_args):
         app_args = new_args
 
     return app_args
+
 
 def _prepare_3dsmaxplus_launch(context, app_args, app_path):
     """
@@ -345,6 +352,7 @@ def _prepare_3dsmaxplus_launch(context, app_args, app_path):
 
     return app_args
 
+
 def _prepare_houdini_launch(context):
     """
     Houdini specific pre-launch environment setup.
@@ -366,6 +374,7 @@ def _prepare_houdini_launch(context):
     except:
         tk_app.log_exception("Error executing engine bootstrap script.")
         raise TankError("Error executing bootstrap script. Please see log for details.")
+
 
 def _prepare_flame_flare_launch(engine_name, context, app_path, app_args):
     """
@@ -416,6 +425,7 @@ def _prepare_flame_flare_launch(engine_name, context, app_path, app_args):
 
     return (app_path, new_args)
 
+
 def _prepare_mari_launch(engine_name, context):
     """
     Mari specific pre-launch environment setup.
@@ -435,6 +445,7 @@ def _prepare_mari_launch(engine_name, context):
     # add the location of our init.py script to the MARI_SCRIPT_PATH
     startup_folder = os.path.join(engine_path, "startup")
     sgtk.util.append_path_to_env_var("MARI_SCRIPT_PATH", startup_folder)
+
 
 def _prepare_photoshop_launch(context):
     """
@@ -515,6 +526,7 @@ def _prepare_photoshop_launch(context):
     startup_path = _get_app_startup_path("photoshop")
     sgtk.util.append_path_to_env_var("PYTHONPATH", startup_path)
 
+
 def _get_app_specific_path(app_dir):
     """
     Returns the path for application specific files for a given application.
@@ -526,6 +538,7 @@ def _get_app_specific_path(app_dir):
     # to determine the bundle's disk location.
     tk_app = sgtk.platform.current_bundle()
     return os.path.join(tk_app.disk_location, "app_specific", app_dir)
+
 
 def _get_app_startup_path(app_name):
     """

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -464,23 +464,23 @@ class SoftwareEntityLauncher(BaseLauncher):
 
     def _scan_for_software(self, engine, versions, products):
         """
-        Use the "auto discovery" feature of an engine launcher to scan the local environment
-        for all related application paths. This information will in turn be used to construct
-        launch commands for the current engine.
+        Use the "auto discovery" feature of an engine launcher to scan the local
+        environment for all related application paths. This information will in
+        turn be used to construct launch commands for the current engine.
 
         :param str engine: Name of the Toolkit engine to construct a launcher for.
         :param list versions: Specific versions (as strings) to filter the auto
-                             discovery results by. If specified, launch commands will only be
-                             registered for executables that match one of the versions in the
-                             list, regardless of which executables were actually discovered.
+            discovery results by. If specified, launch commands will only be
+            registered for executables that match one of the versions in the
+            list, regardless of which executables were actually discovered.
         :param list products: Specific products (as strings) to filter the auto
-                             discovery results by. If specified, launch commands will only be
-                             registered for executables that match one of the products in the
-                             list, regardless of which exectuables were actually discovered.
-                             ex: Houdini FX, Houdini Apprentice, etc.
+            discovery results by. If specified, launch commands will only be
+            registered for executables that match one of the products in the
+            list, regardless of which exectuables were actually discovered.
+            ex: Houdini FX, Houdini Apprentice, etc.
 
         :returns: List of SoftwareVersions related to the specified engine that meet the input
-                  requirements / restrictions.
+            requirements / restrictions.
         """
         # First try to construct the engine launcher for the specified engine.
         try:
@@ -504,7 +504,7 @@ class SoftwareEntityLauncher(BaseLauncher):
         # Next try to scan for available applications for this engine.
         try:
             self._tk_app.log_debug("Scanning for Toolkit engine %s local applications." % engine)
-            software_versions = engine_launcher.scan_software()
+            software_versions = engine_launcher.get_supported_software()
         except Exception, e:
             self._tk_app.log_warning(
                 "Caught unexpected error scanning for DCC applications corresponding "

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -486,7 +486,7 @@ class SoftwareEntityLauncher(BaseLauncher):
         try:
             self._tk_app.log_debug("Initializing engine launcher for %s." % engine)
             engine_launcher = sgtk.platform.create_engine_launcher(
-                self._tk_app.sgtk, self._tk_app.context, engine
+                self._tk_app.sgtk, self._tk_app.context, engine, versions, products
             )
             if not engine_launcher:
                 self._tk_app.log_info(
@@ -504,7 +504,7 @@ class SoftwareEntityLauncher(BaseLauncher):
         # Next try to scan for available applications for this engine.
         try:
             self._tk_app.log_debug("Scanning for Toolkit engine %s local applications." % engine)
-            software_versions = engine_launcher.scan_software(versions, products)
+            software_versions = engine_launcher.scan_software()
         except Exception, e:
             self._tk_app.log_warning(
                 "Caught unexpected error scanning for DCC applications corresponding "

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -9,10 +9,12 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 import os
 import pprint
+import traceback
 
 import sgtk
 
 from .base_launcher import BaseLauncher
+
 
 class SoftwareEntityLauncher(BaseLauncher):
     """
@@ -344,16 +346,16 @@ class SoftwareEntityLauncher(BaseLauncher):
                 software_version.icon,
                 engine_str,
                 software_version.path,
-                "",  # app_args
+                " ".join(software_version.arguments or []),
                 software_version.version,
                 group,
                 group_default,
             )
 
     def _manual_register(
-            self, engine_str, dcc_versions, group, is_group_default,
-            display_name, path, args, icon_path
-        ):
+        self, engine_str, dcc_versions, group, is_group_default,
+        display_name, path, args, icon_path
+    ):
         """
         Parse manual software definition given by input params and register
         one or more commands.
@@ -461,7 +463,6 @@ class SoftwareEntityLauncher(BaseLauncher):
 
         return icon_path
 
-
     def _scan_for_software(self, engine, versions, products):
         """
         Use the "auto discovery" feature of an engine launcher to scan the local
@@ -508,7 +509,7 @@ class SoftwareEntityLauncher(BaseLauncher):
         except Exception, e:
             self._tk_app.log_warning(
                 "Caught unexpected error scanning for DCC applications corresponding "
-                "to Toolkit engine %s:\n%s" % (engine, e)
+                "to Toolkit engine %s:\n%s\n%s" % (engine, e, traceback.format_exc())
             )
             return []
 

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -346,7 +346,7 @@ class SoftwareEntityLauncher(BaseLauncher):
                 software_version.icon,
                 engine_str,
                 software_version.path,
-                " ".join(software_version.arguments or []),
+                " ".join(software_version.args or []),
                 software_version.version,
                 group,
                 group_default,
@@ -505,7 +505,7 @@ class SoftwareEntityLauncher(BaseLauncher):
         # Next try to scan for available applications for this engine.
         try:
             self._tk_app.log_debug("Scanning for Toolkit engine %s local applications." % engine)
-            software_versions = engine_launcher.get_supported_software()
+            software_versions = engine_launcher.scan_software()
         except Exception, e:
             self._tk_app.log_warning(
                 "Caught unexpected error scanning for DCC applications corresponding "


### PR DESCRIPTION
Similar to the `sg_versions` field, `sg_products` allows software scanning to be limited by a set of products. For example, Houdini executable scanning can be limited to `["Houdini FX", "Houdini Core"]`. 

This change adds support for pulling that data from SG as well as passing both the `versions` and `products` lists on when creating the launcher instance. These changes work in conjunction with the changes here: https://github.com/shotgunsoftware/tk-core/pull/410