### PR TITLE
Improved grouping mechanism for registered commands.

### DIFF
--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -88,8 +88,8 @@ class BaseLauncher(object):
             command_name = command_name[:-3]
 
         # Apply some rules to reduce redundancy in the group/display names.
-        (group_name, menu_display_name) = self._get_group_and_menu_display_name(
-                group, menu_name, version)
+        (group_display, menu_display) = self._get_group_and_menu_display(
+            group, menu_name, version)
 
         # special case! @todo: fix this.
         # this is to allow this app to be loaded for sg entities of
@@ -104,17 +104,17 @@ class BaseLauncher(object):
         ]
         if self._tk_app.engine.environment.get("name") not in skip_environments:
             properties = {
-                "title": menu_display_name,
+                "title": menu_display,
                 "short_name": command_name,
                 "description": "Launches and initializes an application environment.",
                 "icon": icon,
-                "group": group_name,
+                "group": group_display,
                 "group_default": group_default
             }
 
             def launch_version():
                 self._launch_callback(
-                    menu_display_name, app_engine, app_path, app_args, version
+                    menu_display, app_engine, app_path, app_args, version
                 )
 
             self._tk_app.log_debug(
@@ -376,7 +376,7 @@ class BaseLauncher(object):
         # Convert the LooseVersions back to strings on return.
         return [str(version) for version in sort_versions]
 
-    def _get_group_and_menu_display_name(self, group_name, display_name, version):
+    def _get_group_and_menu_display(self, group_name, display_name, version):
         """
         Apply some rules to reduce redundancy in the group/display names.
         """
@@ -385,9 +385,9 @@ class BaseLauncher(object):
             # we have a group and the group name matches the display name. only
             # display the version in the menu item.
             display_name = version
-        elif group_name:
+        elif group_name and display_name.startswith(group_name):
             # for all other grouping situations, simply remove the group name
             # from the head of the display name.
-            display_name = display_name.replace(group_name, "").lstrip()
+            display_name = display_name[len(group_name):]
 
         return (group_name, display_name)

--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -89,7 +89,7 @@ class BaseLauncher(object):
 
         # Apply some rules to reduce redundancy in the group/display names.
         (group_display, menu_display) = self._get_group_and_menu_display(
-            group, menu_name, version)
+            group, menu_name)
 
         # special case! @todo: fix this.
         # this is to allow this app to be loaded for sg entities of
@@ -376,16 +376,21 @@ class BaseLauncher(object):
         # Convert the LooseVersions back to strings on return.
         return [str(version) for version in sort_versions]
 
-    def _get_group_and_menu_display(self, group_name, display_name, version):
+    def _get_group_and_menu_display(self, group_name, display_name):
         """
         Apply some rules to reduce redundancy in the group/display names.
+
+        :param str group_name: The group display name as defined by either the
+            SW entity or SW version product name.
+        :param str display_name: The display name which typically includes the
+            product name and version
+
+        Truncate the display name if it includes the group name.
+
+        :returns: tuple of the form (group_name, display_name)
         """
 
-        if group_name and group_name == display_name:
-            # we have a group and the group name matches the display name. only
-            # display the version in the menu item.
-            display_name = version
-        elif group_name and display_name.startswith(group_name):
+        if group_name and display_name.startswith(group_name):
             # for all other grouping situations, simply remove the group name
             # from the head of the display name.
             display_name = display_name[len(group_name):]

--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -87,9 +87,10 @@ class BaseLauncher(object):
         if command_name.endswith("..."):
             command_name = command_name[:-3]
 
-        # Apply some rules to reduce redundancy in the group/display names.
-        (group_display, menu_display) = self._get_group_and_menu_display(
-            group, menu_name)
+        if group and menu_name.startswith(group):
+            # for all other grouping situations, simply remove the group name
+            # from the head of the display name.
+            menu_name = menu_name[len(group):]
 
         # special case! @todo: fix this.
         # this is to allow this app to be loaded for sg entities of
@@ -104,17 +105,17 @@ class BaseLauncher(object):
         ]
         if self._tk_app.engine.environment.get("name") not in skip_environments:
             properties = {
-                "title": menu_display,
+                "title": menu_name,
                 "short_name": command_name,
                 "description": "Launches and initializes an application environment.",
                 "icon": icon,
-                "group": group_display,
+                "group": group,
                 "group_default": group_default
             }
 
             def launch_version():
                 self._launch_callback(
-                    menu_display, app_engine, app_path, app_args, version
+                    menu_name, app_engine, app_path, app_args, version
                 )
 
             self._tk_app.log_debug(
@@ -376,23 +377,3 @@ class BaseLauncher(object):
         # Convert the LooseVersions back to strings on return.
         return [str(version) for version in sort_versions]
 
-    def _get_group_and_menu_display(self, group_name, display_name):
-        """
-        Apply some rules to reduce redundancy in the group/display names.
-
-        :param str group_name: The group display name as defined by either the
-            SW entity or SW version product name.
-        :param str display_name: The display name which typically includes the
-            product name and version
-
-        Truncate the display name if it includes the group name.
-
-        :returns: tuple of the form (group_name, display_name)
-        """
-
-        if group_name and display_name.startswith(group_name):
-            # for all other grouping situations, simply remove the group name
-            # from the head of the display name.
-            display_name = display_name[len(group_name):]
-
-        return (group_name, display_name)

--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -87,6 +87,10 @@ class BaseLauncher(object):
         if command_name.endswith("..."):
             command_name = command_name[:-3]
 
+        # Apply some rules to reduce redundancy in the group/display names.
+        (group_name, menu_display_name) = self._get_group_and_menu_display_name(
+                group, menu_name, version)
+
         # special case! @todo: fix this.
         # this is to allow this app to be loaded for sg entities of
         # type publish but not show up on the Shotgun menu. The
@@ -100,17 +104,17 @@ class BaseLauncher(object):
         ]
         if self._tk_app.engine.environment.get("name") not in skip_environments:
             properties = {
-                "title": menu_name,
+                "title": menu_display_name,
                 "short_name": command_name,
                 "description": "Launches and initializes an application environment.",
                 "icon": icon,
-                "group": group,
+                "group": group_name,
                 "group_default": group_default
             }
 
             def launch_version():
                 self._launch_callback(
-                    menu_name, app_engine, app_path, app_args, version
+                    menu_display_name, app_engine, app_path, app_args, version
                 )
 
             self._tk_app.log_debug(
@@ -372,3 +376,18 @@ class BaseLauncher(object):
         # Convert the LooseVersions back to strings on return.
         return [str(version) for version in sort_versions]
 
+    def _get_group_and_menu_display_name(self, group_name, display_name, version):
+        """
+        Apply some rules to reduce redundancy in the group/display names.
+        """
+
+        if group_name and group_name == display_name:
+            # we have a group and the group name matches the display name. only
+            # display the version in the menu item.
+            display_name = version
+        elif group_name:
+            # for all other grouping situations, simply remove the group name
+            # from the head of the display name.
+            display_name = display_name.replace(group_name, "").lstrip()
+
+        return (group_name, display_name)

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -340,17 +340,20 @@ class SoftwareEntityLauncher(BaseLauncher):
             else:
                 group_default = False
 
-            display_name = self._get_display_name(software_version, group)
+            if not group:
+                group_name = software_version.product
+            else:
+                group_name = group
 
             # perform the registration
             self._register_launch_command(
-                display_name,
+                software_version.display_name,
                 software_version.icon,
                 engine_str,
                 software_version.path,
                 " ".join(software_version.args or []),
                 software_version.version,
-                group,
+                group_name,
                 group_default,
             )
 
@@ -516,22 +519,3 @@ class SoftwareEntityLauncher(BaseLauncher):
             return []
 
         return software_versions
-
-    def _get_display_name(self, sw_version, group_name):
-        """
-        Returns the display name for the given software version to be displayed
-        in the given group.
-
-        :param sw_version: The :class:`SoftwareVersion` to be displayed.
-        :param group_name: The group the :class:`SoftwareVersion` will be
-            displayed in.
-        :return:
-        """
-
-        if group_name == sw_version.product:
-            # group name matches the product. only display the version
-            return sw_version.version
-        elif sw_version.display_name.startswith(group_name):
-            # for all other situations, simply remove the group name from the
-            # head of the sw version display name.
-            return sw_version.display_name.replace(group_name, "").lstrip()

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -340,10 +340,10 @@ class SoftwareEntityLauncher(BaseLauncher):
             else:
                 group_default = False
 
-            if not group:
-                group_name = software_version.product
-            else:
-                group_name = group
+            # Use the product name if no group is defined in the Software
+            # entity entry. This allows for smart grouping default display in
+            # engine UIs.
+            group_name = group or software_version.product
 
             # perform the registration
             self._register_launch_command(

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -340,9 +340,11 @@ class SoftwareEntityLauncher(BaseLauncher):
             else:
                 group_default = False
 
+            display_name = self._get_display_name(software_version, group)
+
             # perform the registration
             self._register_launch_command(
-                software_version.display_name,
+                display_name,
                 software_version.icon,
                 engine_str,
                 software_version.path,
@@ -514,3 +516,22 @@ class SoftwareEntityLauncher(BaseLauncher):
             return []
 
         return software_versions
+
+    def _get_display_name(self, sw_version, group_name):
+        """
+        Returns the display name for the given software version to be displayed
+        in the given group.
+
+        :param sw_version: The :class:`SoftwareVersion` to be displayed.
+        :param group_name: The group the :class:`SoftwareVersion` will be
+            displayed in.
+        :return:
+        """
+
+        if group_name == sw_version.product:
+            # group name matches the product. only display the version
+            return sw_version.version
+        elif sw_version.display_name.startswith(group_name):
+            # for all other situations, simply remove the group name from the
+            # head of the sw version display name.
+            return sw_version.display_name.replace(group_name, "").lstrip()


### PR DESCRIPTION
This PR adds a couple of features to the grouping mechanism in the app launcher:

- If no group is specified via the Software entity, use the product name. This creates smart command groups for the software scanning. For example, "Houdini", "Houdini Core", and "Houdini FX" get grouped automatically without having to specify separate SW entity entries. This feels cleaner than having one big group by default with all of the found products. 
- If the menu name (for grouped commands) starts with the group name, then remove the group name from the start of the menu name. This allows the group to be "Nuke", for example, and the menu items will only display the versions available.

**Screenshot of Software Entities**:
![screen shot 2017-03-09 at 2 30 55 pm](https://cloud.githubusercontent.com/assets/2604646/23767038/13349a38-04d5-11e7-9136-5aca68d5c6bc.png)

**Results in Desktop**:
![screen shot 2017-03-09 at 2 30 47 pm](https://cloud.githubusercontent.com/assets/2604646/23767044/1796e054-04d5-11e7-8262-4f2005653ab8.png)

