### PR TITLE
#41411: Adds "register_all_software" setting.

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -29,12 +29,11 @@ configuration:
                      launch commands for available DCCs.
         default_value: false
 
-    register_all_software:
+    scan_all_projects:
         type: bool
-        description: When true, and when use_software_entity is true, no filtering
-                     of Software entities by project or user restrictions will be
-                     performed. All software launchers will be registered as engine
-                     commands.
+        description: When true, and when use_software_entity is true, launchers
+                     will be registered for all projects instead of only the
+                     current environment's project.
         default_value: false
 
     menu_name:

--- a/info.yml
+++ b/info.yml
@@ -29,6 +29,14 @@ configuration:
                      launch commands for available DCCs.
         default_value: false
 
+    register_all_software:
+        type: bool
+        description: When true, and when use_software_entity is true, no filtering
+                     of Software entities by project or user restrictions will be
+                     performed. All software launchers will be registered as engine
+                     commands.
+        default_value: false
+
     menu_name:
         type: str
         description: Name to appear on the Shotgun menu.

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -191,7 +191,7 @@ class SoftwareEntityLauncher(BaseLauncher):
 
         :returns: A list of shotgun software entity dictionaries
         """
-        register_all_software = self._tk_app.get_setting("register_all_software") or False
+        scan_all_projects = self._tk_app.get_setting("scan_all_projects") or False
 
         # Determine the information to retrieve from Shotgun
         # @todo: The 'sg_software_entity' setting can be removed once the
@@ -209,7 +209,7 @@ class SoftwareEntityLauncher(BaseLauncher):
 
         # If we've been asked to register all software, then we don't want to
         # filter anything out based on user or project restrictions.
-        if not register_all_software:
+        if not scan_all_projects:
             # Next handle Project restrictions. Always include Software entities
             # that have no Project restrictions.
             project_filters = [["sg_projects", "is", None]]
@@ -230,34 +230,34 @@ class SoftwareEntityLauncher(BaseLauncher):
                 # Software entities that do not have any Project restrictions.
                 sw_filters.extend(project_filters)
 
-            # Now Group and User restrictions. Always retrieve Software entities
-            # that have no Group or User restrictions.
-            current_user = self._tk_app.context.user
-            user_group_filters = [
-                ["sg_user_restrictions", "is", None],
-                ["sg_group_restrictions", "is", None],
-            ]
-            if current_user:
-                # If a current User is defined, then retrieve Software
-                # entities that either have A) no Group AND no User
-                # restrictions OR B) current User is included in Group
-                # OR User restrictions.
-                sw_filters.append({
-                    "filter_operator": "or",
-                    "filters": [
-                        {"filter_operator": "and",
-                         "filters": user_group_filters},
-                        {"filter_operator": "or",
-                         "filters": [
-                            ["sg_user_restrictions", "in", current_user],
-                            ["sg_group_restrictions.Group.users", "in", current_user],
-                         ]},
-                    ]
-                })
-            else:
-                # If no User is defined, then only retrieve Software
-                # entities that do not have any Group or User restrictions.
-                sw_filters.extend(user_group_filters)
+        # Now Group and User restrictions. Always retrieve Software entities
+        # that have no Group or User restrictions.
+        current_user = self._tk_app.context.user
+        user_group_filters = [
+            ["sg_user_restrictions", "is", None],
+            ["sg_group_restrictions", "is", None],
+        ]
+        if current_user:
+            # If a current User is defined, then retrieve Software
+            # entities that either have A) no Group AND no User
+            # restrictions OR B) current User is included in Group
+            # OR User restrictions.
+            sw_filters.append({
+                "filter_operator": "or",
+                "filters": [
+                    {"filter_operator": "and",
+                     "filters": user_group_filters},
+                    {"filter_operator": "or",
+                     "filters": [
+                        ["sg_user_restrictions", "in", current_user],
+                        ["sg_group_restrictions.Group.users", "in", current_user],
+                     ]},
+                ]
+            })
+        else:
+            # If no User is defined, then only retrieve Software
+            # entities that do not have any Group or User restrictions.
+            sw_filters.extend(user_group_filters)
 
         # The list of fields we need to retrieve in order to launch the app(s)
         # @todo: When the Software entity becomes native, these field names

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -208,14 +208,14 @@ class SoftwareEntityLauncher(BaseLauncher):
         if not scan_all_projects:
             # Next handle Project restrictions. Always include Software entities
             # that have no Project restrictions.
-            project_filters = [["sg_projects", "is", None]]
+            project_filters = [["projects", "is", None]]
             current_project = self._tk_app.context.project
             if current_project:
                 # If a Project is defined in the current context, retrieve
                 # Software entities that have either no Project restrictions OR
                 # include the context Project as a restriction.
                 project_filters.append(
-                    ["sg_projects", "in", current_project],
+                    ["projects", "in", current_project],
                 )
                 sw_filters.append({
                     "filter_operator": "or",


### PR DESCRIPTION
This setting disables any filtering-out of Software entities based on project or user restrictions. As a result, all software launchers are registered as engine commands. This is intended to be used for building a project/user agnostic cache of engine commands, as will be the case with the toolkit action menu flow.