### PR TITLE
removes special grouping string logic.

### DIFF
--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -87,11 +87,6 @@ class BaseLauncher(object):
         if command_name.endswith("..."):
             command_name = command_name[:-3]
 
-        if group and menu_name.startswith(group):
-            # for all other grouping situations, simply remove the group name
-            # from the head of the display name.
-            menu_name = menu_name[len(group):]
-
         # special case! @todo: fix this.
         # this is to allow this app to be loaded for sg entities of
         # type publish but not show up on the Shotgun menu. The


### PR DESCRIPTION
This removes hard coded logic to work around some shortcomings in desktop.
Instead of working around like this, let's fix the shortcomings!

When things are grouped, their titles now still show up with the full name:

![screen shot 2017-03-30 at 11 06 42](https://cloud.githubusercontent.com/assets/337710/24499679/61003ae0-153a-11e7-9229-2e56b0dbacd8.png)

This means engines which don't support grouping still work nicely.

The issue in desktop is that the recents show up with double labels:

![screen shot 2017-03-30 at 11 07 02](https://cloud.githubusercontent.com/assets/337710/24499721/7dcc1de2-153a-11e7-9e26-7996c91ff159.png)

This is an issue we can address on the desktop side instead.