### PR TITLE
For #44069: Adds a new hook: before_register_command.py

### DIFF
--- a/hooks/before_register_command.py
+++ b/hooks/before_register_command.py
@@ -8,27 +8,23 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-"""
-Before Register Command Hook
-
-This hook is run prior to launchapp registering launcher commands with
-the parent engine. Note: this hook is only run for Software entity 
-launchers.
-"""
-
 import sgtk
 
 HookBaseClass = sgtk.get_hook_baseclass()
 
 class BeforeRegisterCommand(HookBaseClass):
     """
-    Hook to intercept SoftwareLauncher and engine instance name data prior to
-    launcher command registration and alter the engine instance name should that
-    be required.
+    Before Register Command Hook
+
+    This hook is run prior to launchapp registering launcher commands with
+    the parent engine. Note: this hook is only run for Software entity 
+    launchers.
     """
     def determine_engine_instance_name(self, software_version, engine_instance_name):
         """
-        Called when the hook is run prior to launcher command registration.
+        Hook method to intercept SoftwareLauncher and engine instance name data prior to
+        launcher command registration and alter the engine instance name should that
+        be required.
 
         :param software_version: The software version instance constructed when
             the scan software routine was run.

--- a/hooks/before_register_command.py
+++ b/hooks/before_register_command.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Before Register Command Hook
+
+This hook is run prior to launchapp registering launcher commands with
+the parent engine. Note: this hook is only run for Software entity 
+launchers.
+"""
+
+import sgtk
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+class BeforeRegisterCommand(HookBaseClass):
+    """
+    Hook to intercept SoftwareLauncher and engine instance name data prior to
+    launcher command registration.
+    """
+    def execute(self, software_version, engine_instance_name):
+        """
+        Executed when the hook is run prior to launcher command registration.
+
+        :param software_version: The software version instance constructed when
+            the scan software routine was run.
+        :type: :class:`sgtk.platform.SoftwareVersion`
+        :param str engine_instance_name: The name of the engine instance that will
+            be used when SGTK is bootstrapped during launch.
+
+        :returns: A tuple containing a :class:`sgtk.platform.SoftwareVersion`
+            instance followed by the engine instance name. These two items will
+            be used when the launcher command is registered.
+        :rtype: tuple
+        """
+        # The default implementation simply returns what it was given. Should
+        # there be the need to tweak any data in the SoftwareVersion, a new
+        # instance will need to be built using sgtk.platform.SoftwareVersion.
+        return(software_version, engine_instance_name)
+

--- a/hooks/before_register_command.py
+++ b/hooks/before_register_command.py
@@ -23,11 +23,12 @@ HookBaseClass = sgtk.get_hook_baseclass()
 class BeforeRegisterCommand(HookBaseClass):
     """
     Hook to intercept SoftwareLauncher and engine instance name data prior to
-    launcher command registration.
+    launcher command registration and alter the engine instance name should that
+    be required.
     """
-    def execute(self, software_version, engine_instance_name):
+    def determine_engine_instance_name(self, software_version, engine_instance_name):
         """
-        Executed when the hook is run prior to launcher command registration.
+        Called when the hook is run prior to launcher command registration.
 
         :param software_version: The software version instance constructed when
             the scan software routine was run.
@@ -35,13 +36,9 @@ class BeforeRegisterCommand(HookBaseClass):
         :param str engine_instance_name: The name of the engine instance that will
             be used when SGTK is bootstrapped during launch.
 
-        :returns: A tuple containing a :class:`sgtk.platform.SoftwareVersion`
-            instance followed by the engine instance name. These two items will
-            be used when the launcher command is registered.
-        :rtype: tuple
+        :returns: The desired engine instance name.
+        :rtype: str
         """
-        # The default implementation simply returns what it was given. Should
-        # there be the need to tweak any data in the SoftwareVersion, a new
-        # instance will need to be built using sgtk.platform.SoftwareVersion.
-        return(software_version, engine_instance_name)
+        # The default implementation simply returns what it was given.
+        return engine_instance_name
 

--- a/info.yml
+++ b/info.yml
@@ -158,6 +158,14 @@ configuration:
                      to add additional pipeline paths, APIs or other things to the setup, or 
                      specify additional scripts etc to run."
 
+    hook_before_register_command:
+        type: hook
+        default_value: before_register_command
+        description: "This hook is called just before launcher command registration occurs.
+                      it can be used to alter the engine instance name associated with the
+                      launcher should that be required. This hook's methods are only called
+                      when Software entity launchers are being used."
+
 # the Shotgun fields that this app needs in order to operate correctly
 requires_shotgun_fields:
 

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -344,6 +344,13 @@ class SoftwareEntityLauncher(BaseLauncher):
             )
 
         for software_version in software_versions:
+            # run before launch hook
+            self._tk_app.log_debug("Running before register command hook...")
+            software_version, engine_str = self._tk_app.execute_hook(
+                "hook_before_register_command",
+                software_version=software_version,
+                engine_instance_name=engine_str,
+            )
 
             # figure out if this is the group default
             if is_group_default and (software_version.version == sorted_versions[0]):

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -346,8 +346,9 @@ class SoftwareEntityLauncher(BaseLauncher):
         for software_version in software_versions:
             # run before launch hook
             self._tk_app.log_debug("Running before register command hook...")
-            software_version, engine_str = self._tk_app.execute_hook(
+            engine_str = self._tk_app.execute_hook_method(
                 "hook_before_register_command",
+                "determine_engine_instance_name",
                 software_version=software_version,
                 engine_instance_name=engine_str,
             )


### PR DESCRIPTION
This hook will contain a method that can use used to change the engine instance name that will be associated with the launcher command when it is registered. The use case for this will be in tk-config-default2, where we're using Software entities, but need Nuke Studio to be routed to configuration for the tk-nukestudio engine instance rather than tk-nuke, which is what is specified in the Nuke Software entity in Shotgun.