### PR TITLE
For #43822: Bug fix and changes needed for tk-shotgun-launchpublish.

### DIFF
--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -109,9 +109,14 @@ class BaseLauncher(object):
                 "engine_name": app_engine,
             }
 
-            def launch_version():
+            def launch_version(*args, **kwargs):
                 self._launch_callback(
-                    menu_name, app_engine, app_path, app_args, version
+                    menu_name,
+                    app_engine,
+                    app_path,
+                    app_args,
+                    version,
+                    *args, **kwargs
                 )
 
             self._tk_app.log_debug(
@@ -260,7 +265,7 @@ class BaseLauncher(object):
             self._tk_app.sgtk, ctx, "Toolkit_App_Startup", desc, meta
         )
 
-    def _launch_callback(self, menu_name, app_engine, app_path, app_args, version=None):
+    def _launch_callback(self, menu_name, app_engine, app_path, app_args, version=None, file_to_open=None):
         """
         Default method to launch DCC application command based on the current context.
 
@@ -318,7 +323,13 @@ class BaseLauncher(object):
 
         # Launch the DCC
         self._launch_app(
-            menu_name, app_engine, app_path, app_args, self._tk_app.context, version
+            menu_name,
+            app_engine,
+            app_path,
+            app_args,
+            self._tk_app.context,
+            version,
+            file_to_open,
         )
 
     def register_launch_commands(self):

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -346,7 +346,7 @@ class SoftwareEntityLauncher(BaseLauncher):
         for software_version in software_versions:
             # run before launch hook
             self._tk_app.log_debug("Running before register command hook...")
-            engine_str = self._tk_app.execute_hook_method(
+            launch_engine_str = self._tk_app.execute_hook_method(
                 "hook_before_register_command",
                 "determine_engine_instance_name",
                 software_version=software_version,
@@ -368,7 +368,7 @@ class SoftwareEntityLauncher(BaseLauncher):
             self._register_launch_command(
                 software_version.display_name,
                 software_version.icon,
-                engine_str,
+                launch_engine_str,
                 software_version.path,
                 " ".join(software_version.args or []),
                 software_version.version,


### PR DESCRIPTION
Adding compatibility with software launchers in tk-shotgun-launchpublish required a couple of tweaks to the way the callback wrapper function works. We need to be able to pass in a file_to_open argument to the callback and have that passed through to the launch logic itself.