### PR TITLE
For #44069: Adds a skip_engine_instances app setting.

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -134,6 +134,23 @@ configuration:
                      These pieces of the version string are available in the other settings via the
                      {v0}, {v1}, {v2}, ... replacement tokens."
 
+    skip_engine_instances:
+        type: list
+        allows_empty: True
+        values:
+          type: str
+        default_value: []
+        description: "A list of string names of engine instances to skip registering Software
+                     launcher commands for. For example, a value of ['tk-nukestudio'] for this
+                     setting would stop any Software entity launcher commands being registered
+                     with the engine that reference the 'tk-nukestudio' engine instance in that
+                     environment. This can be used to allow for an engine instance to be configured
+                     for a given environment without a launcher existing for it. This is useful
+                     in the case of Nuke Studio, where we want to allow for context changes into
+                     certain environments, but we only want the application to be launchable from
+                     a project environment. This setting only has an impact on Software entity
+                     launchers."
+
     extra:
         type: dict
         description: "Shotgun engine specific extra values. These are defined per Shotgun engine.

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -384,6 +384,16 @@ class SoftwareEntityLauncher(BaseLauncher):
                     )
                     continue
 
+            # We need to check to see if the engine instance associated with
+            # the launch command is something we've been configured to skip.
+            if launch_engine_str in self._tk_app.get_setting("skip_engine_instances"):
+                self._tk_app.log_debug(
+                    "The %s engine instance has been configured to be skipped by way "
+                    "of the skip_engine_instances app setting. The launcher command "
+                    "for %r will not be registered." % (launch_engine_str, software_version)
+                )
+                continue
+
             # figure out if this is the group default
             if is_group_default and (software_version.version == sorted_versions[0]):
                 group_default = True

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -363,9 +363,9 @@ class SoftwareEntityLauncher(BaseLauncher):
             # is determined by the hook. We need to check for the same possible
             # issue here since the requested engine instance has changed.
             if launch_engine_str != engine_str:
-                self._tk_app.log_debug(
+                self._tk_app.logger.debug(
                     "The before_register_command hook changed the engine instance "
-                    "to be %s." % launch_engine_str
+                    "to be %s.", launch_engine_str
                 )
 
                 try:
@@ -377,20 +377,20 @@ class SoftwareEntityLauncher(BaseLauncher):
                         self._tk_app.context,
                     )
                 except sgtk.platform.TankMissingEngineError:
-                    self._tk_app.log_debug(
+                    self._tk_app.logger.debug(
                         "The engine instance requested by before_register_command (%s) "
                         "does not exist in the current environment. The launcher will "
-                        "not be registered as a result." % launch_engine_str
+                        "not be registered as a result.", launch_engine_str
                     )
                     continue
 
             # We need to check to see if the engine instance associated with
             # the launch command is something we've been configured to skip.
             if launch_engine_str in self._tk_app.get_setting("skip_engine_instances"):
-                self._tk_app.log_debug(
+                self._tk_app.logger.debug(
                     "The %s engine instance has been configured to be skipped by way "
                     "of the skip_engine_instances app setting. The launcher command "
-                    "for %r will not be registered." % (launch_engine_str, software_version)
+                    "for %r will not be registered.", launch_engine_str, software_version
                 )
                 continue
 


### PR DESCRIPTION
This can be used to allow an engine instance to be configured for a given environment without a launcher existing for it. This is useful in the case of Nuke Studio, where we want to allow for context changes into certain environments, but we only want the application to be launchable from a project environment.