### PR TITLE
For #44050 Move (in) logging of "Launched Software" metric from "tk-c…

### DIFF
--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -230,9 +230,6 @@ class BaseLauncher(object):
             else:
                 # Emit a launched software metric
                 try:
-
-                    self._tk_app.log_info("NICOLAS: dfasdfasdfasdf")
-
                     # Dedicated try/except block: we wouldn't want a metric-related
                     # exception to prevent execution of the remaining code.
                     engine = sgtk.platform.current_engine()

--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -188,6 +188,7 @@ class BaseLauncher(object):
                     "Launching executable '%s' with args '%s'" %
                     (app_path, app_args)
                 )
+
                 result = self._tk_app.execute_hook(
                     "hook_app_launch", app_path=app_path,
                     app_args=app_args, version=version_string
@@ -228,6 +229,9 @@ class BaseLauncher(object):
                     )
 
             else:
+                # Emit an application launched metric
+                self._log_launched_application_metric(menu_name, app_engine, context, launch_cmd)
+
                 # Write an event log entry
                 self._register_event_log(menu_name, app_engine, context, launch_cmd)
 
@@ -240,6 +244,43 @@ class BaseLauncher(object):
             del sys.path[:]
             sys.path.extend(sys_path_clone)
 
+    def _get_metadata(self, app_engine, command_executed):
+        """
+
+        :return:
+        """
+        return {
+            "core": self._tk_app.sgtk.version,
+            "engine": "%s %s" % (self._tk_app.engine.name, self._tk_app.engine.version),
+            "app": "%s %s" % (self._tk_app.name, self._tk_app.version),
+            "launched_engine": app_engine,
+            "command": command_executed,
+            "platform": sys.platform
+        }
+
+    def _log_launched_application_metric(self, menu_name, app_engine, ctx, command_executed):
+        # Dedicated try/except block we wouldn't want a metric-related exception
+        # to prevent execution of the remaining code.
+        try:
+            from sgtk.util.metrics import EventMetric as EventMetric
+
+            properties =  self._tk_app._get_metrics_properties()
+            meta = self._get_metadata(app_engine, command_executed)
+            meta.update({
+                "context": str(ctx),
+                "menu_name": menu_name
+            })
+            properties.update({
+                "meta": meta
+            })
+            EventMetric.log(
+                EventMetric.GROUP_TOOLKIT,
+                "Launched Software",
+                properties=properties,
+            )
+        except Exception as e:
+            pass
+
     def _register_event_log(self, menu_name, app_engine, ctx, command_executed):
         """
         Writes an event log entry to the shotgun event log, informing
@@ -251,13 +292,7 @@ class BaseLauncher(object):
         :param command_executed: Command (including args) that was used to
                                  launch the DCC.
         """
-        meta = {}
-        meta["core"] = self._tk_app.sgtk.version
-        meta["engine"] = "%s %s" % (self._tk_app.engine.name, self._tk_app.engine.version)
-        meta["app"] = "%s %s" % (self._tk_app.name, self._tk_app.version)
-        meta["launched_engine"] = app_engine
-        meta["command"] = command_executed
-        meta["platform"] = sys.platform
+        meta = self._get_metadata(app_engine, command_executed)
         if ctx.task:
             meta["task"] = ctx.task["id"]
         desc = "%s %s: %s" % (self._tk_app.name, self._tk_app.version, menu_name)

--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -228,6 +228,19 @@ class BaseLauncher(object):
                     )
 
             else:
+                # Emit a launched software metric
+                try:
+
+                    self._tk_app.log_info("NICOLAS: dfasdfasdfasdf")
+
+                    # Dedicated try/except block: we wouldn't want a metric-related
+                    # exception to prevent execution of the remaining code.
+                    engine = sgtk.platform.current_engine()
+                    engine.log_metric("Launched Software")
+
+                except Exception as e:
+                    pass
+
                 # Write an event log entry
                 self._register_event_log(menu_name, app_engine, context, launch_cmd)
 


### PR DESCRIPTION
Here is the metric I'm currently testing out from `tk-multi-launchapp`:

```event_properties":{
   "App":"tk-multi-launchapp",
   "App Version":"v0.9.4",
   "Engine":"tk-desktop",
   "Engine Version":"v2.3.9",
   "Host App":"Desktop",
   "Host App Version":"unknown",
   "event_group":"Toolkit",
   "event_name":"Launched Software",
   "event_type":"event",
   "from_api":true,
   "meta.app":"tk-multi-launchapp v0.9.4",
   "meta.command":"open -n -a \"/Applications/Autodesk/maya2018/Maya.app\"",
   "meta.context":"Project nicolas-amplitude-test-project",
   "meta.core":"HEAD",
   "meta.engine":"tk-desktop v2.3.9",
   "meta.launched_engine":"tk-maya",
   "meta.menu_name":"Maya 2018",
   "meta.platform":"darwin"
}
```

@robblau 
The added 'meta' is meant to fill in the hole of not having host_info fields available at this time in the application loading/launching process.