### PR TITLE
For #44763: Detects Flame launches in the case of a Software entity launch.

### DIFF
--- a/hooks/app_launch.py
+++ b/hooks/app_launch.py
@@ -35,11 +35,21 @@ class AppLaunch(tank.Hook):
         :returns: (dict) The two valid keys are 'command' (str) and 'return_code' (int).
         """
         system = sys.platform
+        flame_launcher = "tk-flame/python/startup/app_launcher.py"
+
         if system == "linux2":
             # on linux, we just run the executable directly
             cmd = "%s %s &" % (app_path, app_args)
         
-        elif self.parent.get_setting("engine") in ["tk-flame", "tk-flare"]:
+        elif self.parent.get_setting("engine") in ["tk-flame", "tk-flare"] or flame_launcher in app_args:
+            # NOTE: When working with Software entity launchers, we don't
+            # have the advantage of an engine name registered with the app
+            # instance. Instead, we can rely on the fact that we know that
+            # the app_launch.py script bundled with tk-flame will be included
+            # in the app_args string, which means we know that "tk-flame"
+            # will be in that path. As such, we can check for that to know
+            # whether this is a Flame launch.
+            #
             # flame and flare works in a different way from other DCCs
             # on both linux and mac, they run unix-style command line
             # and on the mac the more standardized "open" command cannot


### PR DESCRIPTION
This adds a hack to an existing hack. It's unfortunate, but it does work. Since this is in support of a legacy workflow for Flame, it's a little more livable. 