### PR TITLE
Adds support to the tk-multi-launchapp to support the deny_permissions option for adding commands/app launchers.

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -94,6 +94,14 @@ configuration:
                       display in applications that show a single button for each named group."
         default_value: False
 
+    deny_permissions:
+        type: list
+        allows_empty: True
+        values:
+            type: str
+        default_value: []
+        description: "List of permission groups to exclude this application launcher for (e.g. ['Artist'])."
+
     defer_keyword:
         type: str
         default_value: ""

--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -49,6 +49,7 @@ class BaseLauncher(object):
             version=None,
             group=None,
             group_default=True,
+            deny_permissions=None,
         ):
         """
         Register a launch command with the current engine.
@@ -70,6 +71,8 @@ class BaseLauncher(object):
                                    indicate whether to launch this command if the group is
                                    selected instead of an individual command. This value is
                                    also interpreted by the engine the command is registered with.
+        :param list deny_permissions: (Optional) List of permission groups to exclude this
+                                      menu item for (e.g. ``["Artist"]``)
         """
         # do the {version} replacement if needed
         icon = apply_version_to_setting(app_icon, version)
@@ -107,6 +110,7 @@ class BaseLauncher(object):
                 "group": group,
                 "group_default": group_default,
                 "engine_name": app_engine,
+                "deny_permissions": deny_permissions,
             }
 
             def launch_version(*args, **kwargs):

--- a/python/tk_multi_launchapp/single_config_launcher.py
+++ b/python/tk_multi_launchapp/single_config_launcher.py
@@ -32,6 +32,7 @@ class SingleConfigLauncher(BaseLauncher):
         self._app_engine = self._tk_app.get_setting("engine")
         self._app_group = self._tk_app.get_setting("group")
         self._is_group_default = self._tk_app.get_setting("group_default")
+        self._deny_permissions = self._tk_app.get_setting("deny_permissions")
 
     def register_launch_commands(self):
         """
@@ -95,7 +96,8 @@ class SingleConfigLauncher(BaseLauncher):
                     self._app_args,
                     version,
                     self._app_group,
-                    (version == sorted_versions[0])  # group_default
+                    (version == sorted_versions[0]),  # group_default
+                    self._deny_permissions,
                 )
         else:
             # No replacements defined, just register with the raw values
@@ -108,6 +110,7 @@ class SingleConfigLauncher(BaseLauncher):
                 None,
                 self._app_group,
                 self._is_group_default,
+                self._deny_permissions,
             )
 
     def launch_from_path(self, path, version=None):


### PR DESCRIPTION
This adds ``deny_permissions`` to the configuration options for single config launcher apps.  This option will be passed through to the engine when registering commands/launchers.  I have another [PR for tk-desktop](https://github.com/shotgunsoftware/tk-desktop/pull/88) to support this option.