### PR TITLE
#45898 Supplies the engine name to the app launch hooks

### DIFF
--- a/hooks/app_launch.py
+++ b/hooks/app_launch.py
@@ -23,36 +23,28 @@ class AppLaunch(tank.Hook):
     Hook to run an application.
     """
     
-    def execute(self, app_path, app_args, version, **kwargs):
+    def execute(self, app_path, app_args, version, engine_name, **kwargs):
         """
         The execute functon of the hook will be called to start the required application
         
         :param app_path: (str) The path of the application executable
         :param app_args: (str) Any arguments the application may require
-        :param version: (str) version of the application being run if set in the "versions" settings
-                              of the Launcher instance, otherwise None
+        :param version: (str) version of the application being run if set in the
+            "versions" settings of the Launcher instance, otherwise None
+        :param engine_name (str) The name of the engine associated with the
+            software about to be launched.
 
         :returns: (dict) The two valid keys are 'command' (str) and 'return_code' (int).
         """
-        system = sys.platform
 
-        # NOTE: When working with Software entity launchers, we don't have the
-        # advantage of an engine name configured with the app instance. We can
-        # check against that first for manual launchers. Failing that, we can
-        # check the engine name env variable set by the flame engine during
-        # startup.
-        flame_engine_instance_names = ["tk-flame", "tk-flare"]
-        flame_launch = (
-            self.parent.get_setting("engine") in flame_engine_instance_names or
-            os.environ.get("TOOLKIT_ENGINE_NAME") == "tk-flame"
-        )
+        system = sys.platform
 
         if system == "linux2":
             # on linux, we just run the executable directly
             cmd = "%s %s &" % (app_path, app_args)
         
-        elif flame_launch:
-            # flame and flare works in a different way from other DCCs
+        elif engine_name == "tk-flame":
+            # flame and flare work in a different way from other DCCs
             # on both linux and mac, they run unix-style command line
             # and on the mac the more standardized "open" command cannot
             # be utilized.

--- a/hooks/before_app_launch.py
+++ b/hooks/before_app_launch.py
@@ -16,7 +16,6 @@ to set environment variables or run scripts as part of the app initialization.
 """
 
 import os
-import sys
 import tank
 
 class BeforeAppLaunch(tank.Hook):
@@ -24,14 +23,16 @@ class BeforeAppLaunch(tank.Hook):
     Hook to set up the system prior to app launch.
     """
     
-    def execute(self, app_path, app_args, version, **kwargs):
+    def execute(self, app_path, app_args, version, engine_name, **kwargs):
         """
         The execute functon of the hook will be called prior to starting the required application        
         
         :param app_path: (str) The path of the application executable
         :param app_args: (str) Any arguments the application may require
-        :param version: (str) version of the application being run if set in the "versions" settings
-                              of the Launcher instance, otherwise None
+        :param version: (str) version of the application being run if set in the
+            "versions" settings of the Launcher instance, otherwise None
+        :param engine_name (str) The name of the engine associated with the
+            software about to be launched.
 
         """
 
@@ -43,16 +44,3 @@ class BeforeAppLaunch(tank.Hook):
         
         # you can set environment variables like this:
         # os.environ["MY_SETTING"] = "foo bar"
-        
-        # if you are using a shared hook to cover multiple applications,
-        # you can use the engine setting to figure out which application 
-        # is currently being launched:
-        #
-        # > multi_launchapp = self.parent
-        # > if multi_launchapp.get_setting("engine") == "tk-nuke":
-        #       do_something()
-        
-        
-        
-        
-        

--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -172,8 +172,11 @@ class BaseLauncher(object):
             # run before launch hook
             self._tk_app.log_debug("Running before app launch hook...")
             self._tk_app.execute_hook(
-                "hook_before_app_launch", app_path=app_path,
-                app_args=app_args, version=version_string
+                "hook_before_app_launch",
+                app_path=app_path,
+                app_args=app_args,
+                version=version_string,
+                engine_name=app_engine,
             )
 
             # Ticket 26741: Avoid having odd DLL loading issues on windows
@@ -189,8 +192,11 @@ class BaseLauncher(object):
                     (app_path, app_args)
                 )
                 result = self._tk_app.execute_hook(
-                    "hook_app_launch", app_path=app_path,
-                    app_args=app_args, version=version_string
+                    "hook_app_launch",
+                    app_path=app_path,
+                    app_args=app_args,
+                    version=version_string,
+                    engine_name=app_engine,
                 )
                 launch_cmd = result.get("command")
                 return_code = result.get("return_code")


### PR DESCRIPTION
This changes adds the engine name to the arguments supplied to the app launch hooks. This should help ease transition from classic launch configuration to Software entities where the engine name is not available via the settings. 