### PR TITLE
For SG-4623, multiple project on software entity fix

### DIFF
--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -19,6 +19,7 @@ from .util import apply_version_to_setting, get_clean_version_string
 from .util import clear_dll_directory, restore_dll_directory
 from .prepare_apps import prepare_launch_for_engine
 
+
 class BaseLauncher(object):
     """
     Functionality to register engine commands that launch DCC
@@ -40,16 +41,17 @@ class BaseLauncher(object):
         }[sys.platform]
 
     def _register_launch_command(
-            self,
-            app_menu_name,
-            app_icon,
-            app_engine,
-            app_path,
-            app_args,
-            version=None,
-            group=None,
-            group_default=True,
-        ):
+        self,
+        app_menu_name,
+        app_icon,
+        app_engine,
+        app_path,
+        app_args,
+        version=None,
+        group=None,
+        group_default=True,
+        software_entity_id=None
+    ):
         """
         Register a launch command with the current engine.
 
@@ -70,6 +72,8 @@ class BaseLauncher(object):
                                    indicate whether to launch this command if the group is
                                    selected instead of an individual command. This value is
                                    also interpreted by the engine the command is registered with.
+        :param int software_entity_id: If set, this is the entity id of the software entity that
+            is associated with this launch command.
         """
         # do the {version} replacement if needed
         icon = apply_version_to_setting(app_icon, version)
@@ -106,8 +110,10 @@ class BaseLauncher(object):
                 "icon": icon,
                 "group": group,
                 "group_default": group_default,
-                "engine_name": app_engine,
+                "engine_name": app_engine
             }
+
+            properties["software_entity_id"] = software_entity_id
 
             def launch_version(*args, **kwargs):
                 self._launch_callback(
@@ -128,9 +134,9 @@ class BaseLauncher(object):
             )
 
     def _launch_app(
-            self, menu_name, app_engine, app_path, app_args, context,
-            version=None, file_to_open=None
-        ):
+        self, menu_name, app_engine, app_path, app_args, context,
+        version=None, file_to_open=None
+    ):
         """
         Launches an application. No environment variable change is
         leaked to the outside world.
@@ -241,7 +247,7 @@ class BaseLauncher(object):
                     engine = sgtk.platform.current_engine()
                     engine.log_metric("Launched Software")
 
-                except Exception as e:
+                except Exception:
                     pass
 
                 # Write an event log entry
@@ -399,4 +405,3 @@ class BaseLauncher(object):
 
         # Convert the LooseVersions back to strings on return.
         return [str(version) for version in sort_versions]
-

--- a/python/tk_multi_launchapp/software_entity_launcher.py
+++ b/python/tk_multi_launchapp/software_entity_launcher.py
@@ -112,7 +112,8 @@ class SoftwareEntityLauncher(BaseLauncher):
                     dcc_versions,
                     dcc_products,
                     app_group,
-                    is_group_default
+                    is_group_default,
+                    sw_entity["id"]
                 )
 
             else:
@@ -150,7 +151,8 @@ class SoftwareEntityLauncher(BaseLauncher):
                     app_display_name,
                     app_path,
                     app_args,
-                    icon_path
+                    icon_path,
+                    sw_entity["id"]
                 )
 
     def launch_from_path(self, path, version=None):
@@ -302,7 +304,9 @@ class SoftwareEntityLauncher(BaseLauncher):
 
         return sw_entities
 
-    def _scan_for_software_and_register(self, engine_str, dcc_versions, dcc_products, group, is_group_default):
+    def _scan_for_software_and_register(
+        self, engine_str, dcc_versions, dcc_products, group, is_group_default, software_entity_id
+    ):
         """
         Scan for installed software and register commands for all entries detected.
 
@@ -415,11 +419,12 @@ class SoftwareEntityLauncher(BaseLauncher):
                 software_version.version,
                 group_name,
                 group_default,
+                software_entity_id
             )
 
     def _manual_register(
         self, engine_str, dcc_versions, group, is_group_default,
-        display_name, path, args, icon_path
+        display_name, path, args, icon_path, software_entity_id
     ):
         """
         Parse manual software definition given by input params and register
@@ -470,6 +475,7 @@ class SoftwareEntityLauncher(BaseLauncher):
                     version,
                     group,
                     group_default,
+                    software_entity_id
                 )
 
         else:
@@ -483,6 +489,7 @@ class SoftwareEntityLauncher(BaseLauncher):
                 None,  # version
                 group,
                 is_group_default,
+                software_entity_id
             )
 
     def _extract_thumbnail(self, entity_type, entity_id, sg_thumb_url):


### PR DESCRIPTION
This adds extra information to the properties of the launch action so that we are aware which software entity an action is coming from.