### PR TITLE
SG-12573 Fix to allow multiple arguments to be supplied to the launch app on Mac

### DIFF
--- a/hooks/app_launch.py
+++ b/hooks/app_launch.py
@@ -58,7 +58,7 @@ class AppLaunch(tank.Hook):
                 # executable form.
                 cmd = "open -n -a \"%s\"" % (app_path)
                 if app_args:
-                    cmd += " --args \"%s\"" % app_args.replace("\"", "\\\"")
+                    cmd += " --args %s" % app_args
             else:
                 cmd = "%s %s &" % (app_path, app_args)
         


### PR DESCRIPTION
Before the fix, on Mac the launch app hook would encapsulate all passed arguments in one string, making them essentially a single argument. This fix means that the args won't be passed to the executable as one string 

Before 
given the following args:
```
 "/Shotgun_Media/Big Buck Bunny/09_tree_trunk_011_COMP_001/09_tree_trunk_011_COMP_001.mov" -pyeval "print 'hello'"
```
you would get
```
open -n -a "/Applications/RV64.app" --args "\"/Shotgun_Media/Big Buck Bunny/09_tree_trunk_011_COMP_001/09_tree_trunk_011_COMP_001.mov\" -pyeval \"print 'hello'\""
```
now you get:
```
open -n -a "/Applications/RV64.app" --args "/Shotgun_Media/Big Buck Bunny/09_tree_trunk_011_COMP_001/09_tree_trunk_011_COMP_001.mov" -pyeval "print 'hello'"
```

I can see a potential for breaking existing setup here though maybe.
For example, if you were passing a path with spaces such as :

```
"/Shotgun_Media/Big Buck Bunny/09_tree_trunk_011_COMP_001/09_tree_trunk_011_COMP_001.mov"
```
You would need to encapsulate it in quotations in the string before hand
```
"\"/Shotgun_Media/Big Buck Bunny/09_tree_trunk_011_COMP_001/09_tree_trunk_011_COMP_001.mov\""
```