### PR TITLE
Removed erroneous extra "App"

### DIFF
--- a/hooks/app_launch.py
+++ b/hooks/app_launch.py
@@ -67,7 +67,7 @@ class AppLaunch(tank.Hook):
         else:
             # on windows, we run the start command in order to avoid
             # any command shells popping up as part of the application launch.
-            cmd = 'start /B "App" "%s" %s' % (app_path, app_args)
+            cmd = 'start /B "%s" %s' % (app_path, app_args)
 
         # run the command to launch the app
         exit_code = os.system(cmd)


### PR DESCRIPTION
Super quick one!

Spotted from [rez-shotgun Google Group](https://groups.google.com/d/msg/rez-config/Bmq0Kl4GhGI/XmBgSZKzBAAJ), it seems the "App" should not be there when launching Windows applications.

See also [official start command documentations](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/start)