### PR TITLE
SG-31402 Bugfix/use first version as default version

### DIFF
--- a/python/tk_multi_launchapp/single_config_launcher.py
+++ b/python/tk_multi_launchapp/single_config_launcher.py
@@ -80,16 +80,15 @@ class SingleConfigLauncher(BaseLauncher):
         if app_versions:
             # If a list of versions has been specified, the "group_default" configuration
             # setting is invalid because it cannot be applied to each generated command.
-            # Set the group default to the highest version in the list instead.
-            sorted_versions = self._sort_versions(app_versions)
+            # Set the group default to the first version in the list instead.
             self._tk_app.log_debug(
                 "Unable to apply group '%s' group_default value to list of DCC versions : %s. "
-                "Setting group '%s' default to highest version '%s' instead."
+                "Setting group '%s' default to first version '%s' instead."
                 % (
                     self._app_group,
-                    sorted_versions,
+                    app_versions,
                     self._app_group,
-                    sorted_versions[0],
+                    app_versions[0],
                 )
             )
 

--- a/python/tk_multi_launchapp/single_config_launcher.py
+++ b/python/tk_multi_launchapp/single_config_launcher.py
@@ -93,7 +93,7 @@ class SingleConfigLauncher(BaseLauncher):
                 )
             )
 
-            for version in app_versions:
+            for i, version in enumerate(app_versions):
                 self._register_launch_command(
                     self._app_menu_name,
                     app_icon,
@@ -102,7 +102,7 @@ class SingleConfigLauncher(BaseLauncher):
                     self._app_args,
                     version,
                     self._app_group,
-                    (version == sorted_versions[0])  # group_default
+                    (i == 0)  # First version is group_default
                     # We don't pass in a software entity id, since app is coming from
                     # the configuration.
                 )


### PR DESCRIPTION
Within the [info.yml](https://github.com/shotgunsoftware/tk-multi-launchapp/blob/b252c37f142bb3946724480352d999afc335422e/info.yml#L132) file, the description for the `versions` key mentions `The first version in the list will be considered the 'default' version if the engine running the app supports the concept.`

However, the current code disregards this ordering and always picks the latest version as default instead in [single_config_launcher.py](https://github.com/shotgunsoftware/tk-multi-launchapp/blob/b252c37f142bb3946724480352d999afc335422e/python/tk_multi_launchapp/single_config_launcher.py#L105)

This is an issue as:
1. It does not match what the description says (unless I am misunderstanding it ?)
2. One of our use-case for declaring multiple app versions is to let some artists have a sneak-peak on more recent versions of apps, in which case we do not want the latest version to be considered the default.

This PR restore the expected behavior by always picking the first version listed as the default version.

Note similar behavior seems to be happening in [software_entity_launcher.py](https://github.com/shotgunsoftware/tk-multi-launchapp/blob/master/python/tk_multi_launchapp/software_entity_launcher.py), however I haven't modified it since we do not currently register our software in Shotgrid.