### PR TITLE
Shadowmachine request: Add option to disable the launch indicator

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -197,6 +197,13 @@ configuration:
                       launcher should that be required. This hook's methods are only called
                       when Software entity launchers are being used."
 
+    show_launch_indicator:
+        type: bool
+        default_value: True
+        description: "Option to show the launch indicator spinner, which is a nice feature for apps that
+                      take a while to launch. For apps that open quickly, however, it can interfere
+                      because it lingers modally in the center of the screen for a set amount of time."
+
 # the Shotgun fields that this app needs in order to operate correctly
 requires_shotgun_fields:
 

--- a/python/tk_multi_launchapp/base_launcher.py
+++ b/python/tk_multi_launchapp/base_launcher.py
@@ -284,8 +284,8 @@ class BaseLauncher(object):
                     pass
                 # Write an event log entry
                 self._register_event_log(menu_name, app_engine, context, launch_cmd)
-                # got UI support. Launch dialog with nice message
-                if self._tk_app.engine.has_ui:
+                # got UI support. Launch dialog with nice message unless disabled in configuration.
+                if self._tk_app.engine.has_ui and self._tk_app.get_setting("show_launch_indicator"):
                     self.launch_indicator(app_path)
 
         except Exception as launch_app_error:


### PR DESCRIPTION
We use launch app to open a non-default dcc which opens very quickly.

The Launch indicator widget introduced recently is nice for the normal things like Nuke, Maya, AfterEffects etc., but for apps that open quickly, it just gets in the way.